### PR TITLE
update to new sensor interface

### DIFF
--- a/include/scrimmage/plugins/sensor/NoisyContacts/NoisyContacts.h
+++ b/include/scrimmage/plugins/sensor/NoisyContacts/NoisyContacts.h
@@ -42,7 +42,8 @@ class NoisyContacts : public scrimmage::Sensor {
 public:
     NoisyContacts() {}
     virtual void init(std::map<std::string,std::string> &params);
-    virtual scrimmage::MessageBasePtr sensor_msg(double t, bool &valid);
+    virtual boost::optional<scrimmage::MessageBasePtr> sensor_msg(double t);
+
 protected:        
     std::shared_ptr<std::default_random_engine> gener_;
     std::vector<std::shared_ptr<std::normal_distribution<double>>> pos_noise_;

--- a/include/scrimmage/plugins/sensor/NoisyState/NoisyState.h
+++ b/include/scrimmage/plugins/sensor/NoisyState/NoisyState.h
@@ -43,7 +43,7 @@ class NoisyState : public scrimmage::Sensor {
 public:
     NoisyState() {}
     virtual void init(std::map<std::string,std::string> &params);
-    virtual scrimmage::MessageBasePtr sensor_msg(double t, bool &valid);
+    virtual boost::optional<scrimmage::MessageBasePtr> sensor_msg(double t);
 protected:
 
     std::shared_ptr<std::default_random_engine> gener_;

--- a/include/scrimmage/plugins/sensor/SimpleCamera/SimpleCamera.h
+++ b/include/scrimmage/plugins/sensor/SimpleCamera/SimpleCamera.h
@@ -30,27 +30,24 @@
  *
  */
 
-#ifndef SIMPLE_CAMERA_H_
-#define SIMPLE_CAMERA_H_
+#ifndef INCLUDE_SCRIMMAGE_PLUGINS_SENSOR_SIMPLECAMERA_SIMPLECAMERA_H_
+#define INCLUDE_SCRIMMAGE_PLUGINS_SENSOR_SIMPLECAMERA_SIMPLECAMERA_H_
 
 #include <scrimmage/sensor/Sensor.h>
-#include <scrimmage/entity/Entity.h>
-#include <scrimmage/entity/Contact.h>
+
+#include <map>
+#include <string>
 
 class SimpleCamera : public scrimmage::Sensor {
-public:
-    SimpleCamera() {}
-    virtual void init(std::map<std::string,std::string> &params);
-    virtual bool sense(double t, double dt);
-    std::map<int, scrimmage::Contact> &sensed_contacts() {return sensed_contacts_;}
-    
-protected:
-    std::map<int, scrimmage::Contact> sensed_contacts_;
-    double range_;
-    double fov_azimuth_;
-    double fov_elevation_;
-    bool draw_cone_;
-private:     
+ public:
+    virtual void init(std::map<std::string, std::string> &params);
+    virtual boost::optional<scrimmage::MessageBasePtr> sensor_msg(double t);
+
+ protected:
+    double range_ = 0;
+    double fov_az_ = 0;
+    double fov_el_ = 0;
+    bool draw_cone_ = false;
 };
 
-#endif
+#endif // INCLUDE_SCRIMMAGE_PLUGINS_SENSOR_SIMPLECAMERA_SIMPLECAMERA_H_

--- a/src/plugins/autonomy/Straight/Straight.cpp
+++ b/src/plugins/autonomy/Straight/Straight.cpp
@@ -116,37 +116,27 @@ bool Straight::step_autonomy(double t, double dt)
     // Read data from sensors...
     sc::State own_state;
     for (auto kv : parent_->sensors()) {
-        bool valid;
         if (kv.first == "NoisyState") {
-            auto msg = kv.second->sense<sc::Message<sc::State>>(t, valid);
-            if (valid) {
-                own_state = msg->data;
+            auto msg = kv.second->sense<sc::State>(t);
+            if (msg) {
+                own_state = (*msg)->data;
             }
             
         } else if (kv.first == "NoisyContacts") {
-            auto msg = kv.second->sense<sc::Message<std::list<sc::Contact>>>(t, valid);
-            //if (valid) {
-            //    cout << "Contacts: " << endl;
-            //    for (sc::Contact c : msg->data) {
-            //        cout << "ID: " << c.id().id() << endl;
-            //        cout << "----------------------" << endl;
-            //        cout << "Pos: " << c.state()->pos() << endl;
-            //    }
-            //}
-            
+            auto msg = kv.second->sense<std::list<sc::Contact>>(t);
         } else if (kv.first == "ContactBlobCamera") {
 #if ENABLE_OPENCV == 1
             if (show_camera_images_ || save_camera_images_) {
-                auto msg = kv.second->sense<sc::Message<ContactBlobCameraType>>(t, valid);
-                if (valid) {
+                auto msg = kv.second->sense<ContactBlobCameraType>(t);
+                if (msg) {
                     if (save_camera_images_) {
                         std::string img_name = "./imgs/camera_" +
                             std::to_string(frame_number_++) + ".png";
-                        cv::imwrite(img_name, msg->data.frame);
+                        cv::imwrite(img_name, (*msg)->data.frame);
                     }
 
                     if (show_camera_images_) {
-                        cv::imshow("Camera Sensor", msg->data.frame);
+                        cv::imshow("Camera Sensor", (*msg)->data.frame);
                         cv::waitKey(1);
                     }
                 }

--- a/src/plugins/sensor/CMakeLists.txt
+++ b/src/plugins/sensor/CMakeLists.txt
@@ -1,4 +1,4 @@
-#add_subdirectory(SimpleCamera)
+add_subdirectory(SimpleCamera)
 add_subdirectory(NoisyState)
 add_subdirectory(NoisyContacts)
 if (OPENCV_FOUND)

--- a/src/plugins/sensor/NoisyContacts/NoisyContacts.cpp
+++ b/src/plugins/sensor/NoisyContacts/NoisyContacts.cpp
@@ -97,7 +97,7 @@ void NoisyContacts::init(std::map<std::string,std::string> &params)
     return;
 }
 
-sc::MessageBasePtr NoisyContacts::sensor_msg(double t, bool &valid)
+boost::optional<scrimmage::MessageBasePtr> NoisyContacts::sensor_msg(double t)
 {
     auto msg = std::make_shared<sc::Message<std::list<sc::Contact>>>();
 
@@ -137,6 +137,5 @@ sc::MessageBasePtr NoisyContacts::sensor_msg(double t, bool &valid)
         msg->data.push_back(c);
     }
 
-    valid = true;
-    return msg;
+    return boost::optional<sc::MessageBasePtr>(msg);
 }

--- a/src/plugins/sensor/NoisyState/NoisyState.cpp
+++ b/src/plugins/sensor/NoisyState/NoisyState.cpp
@@ -97,7 +97,7 @@ void NoisyState::init(std::map<std::string,std::string> &params)
     return;
 }
 
-sc::MessageBasePtr NoisyState::sensor_msg(double t, bool &valid)
+boost::optional<scrimmage::MessageBasePtr> NoisyState::sensor_msg(double t)
 {
     // Make a copy of the current state
     sc::State ns = *(parent_->state());
@@ -116,6 +116,5 @@ sc::MessageBasePtr NoisyState::sensor_msg(double t, bool &valid)
         * sc::Quaternion(Eigen::Vector3d::UnitY(), (*orient_noise_[1])(*gener_))
         * sc::Quaternion(Eigen::Vector3d::UnitZ(), (*orient_noise_[2])(*gener_));
 
-    valid = true;
-    return msg;
+    return boost::optional<scrimmage::MessageBasePtr>(msg);
 }

--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -1058,12 +1058,6 @@ namespace scrimmage {
                     }
                 }
 
-                //for (auto &kv : task->ent->sensors()) {
-                //    for (SensorPtr &sensor : kv.second) {
-                //        success &= sensor->sense(t_, dt_);
-                //    }
-                //}
-
                 for (AutonomyPtr &autonomy : task->ent->autonomies()) {
                     success &= autonomy->step_autonomy(t_, dt_);
                 }
@@ -1117,12 +1111,6 @@ namespace scrimmage {
                         sensable->update(t_, dt_);
                     }
                 }
-
-                //for (auto &kv : ent->sensors()) {
-                //    for (SensorPtr &sensor : kv.second) {
-                //        sensor->sense(t_, dt_);
-                //    }
-                //}
 
                 for (AutonomyPtr &autonomy : ent->autonomies()) {
                     autonomy->step_autonomy(t_, dt_);

--- a/test/test_sensor.cpp
+++ b/test/test_sensor.cpp
@@ -1,0 +1,90 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @date 31 July 2017
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+#include <gtest/gtest.h>
+#include <scrimmage/plugins/sensor/SimpleCamera/SimpleCamera.h>
+#include <scrimmage/plugins/sensor/NoisyState/NoisyState.h>
+#include <scrimmage/entity/Entity.h>
+#include <scrimmage/math/State.h>
+#include <scrimmage/pubsub/Message.h>
+#include <scrimmage/common/RTree.h>
+#include <scrimmage/Hash.h>
+
+namespace sc = scrimmage;
+
+class SensorTest : public ::testing::Test {
+ protected:
+    virtual void SetUp() {
+        sc::ContactMapPtr contacts(new sc::ContactMap());
+        (*contacts)[1].id() = sc::ID(1, 1, 1);
+        (*contacts)[1].state()->pos() = Eigen::Vector3d::Zero();
+        (*contacts)[1].state()->pos() = Eigen::Vector3d::Zero();
+        (*contacts)[1].state()->quat().set(0, 0, 0);
+
+        (*contacts)[2].id() = sc::ID(2, 1, 1);
+        (*contacts)[2].state()->pos() = Eigen::Vector3d(10, 0, 0);
+        (*contacts)[2].state()->vel() = Eigen::Vector3d::Zero();
+        (*contacts)[2].state()->quat().set(0, 0, 0);
+
+        parent_ = std::make_shared<sc::Entity>();
+
+        parent_->rtree() = std::make_shared<scrimmage::RTree>();
+        parent_->rtree()->init(2);
+        parent_->rtree()->add(contacts->at(1).state()->pos(), contacts->at(1).id());
+        parent_->rtree()->add(contacts->at(2).state()->pos(), contacts->at(2).id());
+
+        parent_->id() = sc::ID(1, 1, 1);
+        parent_->contacts() = contacts;
+    }
+
+    sc::EntityPtr parent_;
+};
+
+TEST_F(SensorTest, simple_camera) {
+
+    std::shared_ptr<SimpleCamera> simple_camera(new SimpleCamera());
+    std::map<std::string, std::string> params
+        {{"range", "100"}, {"fov_az", "90"},
+        {"fov_el", "90"}, {"draw_cone", "false"}};
+    simple_camera->init(params);
+
+    simple_camera->set_parent(parent_);
+    simple_camera->parent()->contacts() = parent_->contacts();
+    auto msg = simple_camera->sense<std::unordered_set<sc::ID>>(0);
+    EXPECT_TRUE(msg);
+    std::unordered_set<sc::ID> &msg_data = (*msg)->data;
+
+    EXPECT_TRUE(msg_data.size() == 1);
+
+    auto &contacts = *parent_->contacts();
+    EXPECT_TRUE(msg_data.count(contacts[2].id()) == 1);
+    EXPECT_TRUE(msg_data.count(contacts[1].id()) == 0);
+}


### PR DESCRIPTION
1) changes the signature to use boost::optional instead of updating a
   reference to valid
2) adds enable_if to Sensor class so that users do not need to specify
   sense<sc::Message<data_type>>. They can now just do sense<data_type>
3) enabled SimpleCamera
4) add test for SimpleCamera