### PR TITLE
Quad yaw external control

### DIFF
--- a/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegrator.h
+++ b/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegrator.h
@@ -65,6 +65,7 @@ class DoubleIntegrator : public scrimmage::MotionModel {
     Eigen::Vector3d ctrl_u_;
     double max_vel_ = std::numeric_limits<double>::infinity();
     double max_acc_ = std::numeric_limits<double>::infinity();
+    bool motion_model_sets_yaw_;
 };
 
 #endif // INCLUDE_SCRIMMAGE_PLUGINS_MOTION_DOUBLEINTEGRATOR_DOUBLEINTEGRATOR_H_

--- a/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegrator.h
+++ b/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegrator.h
@@ -57,12 +57,12 @@ class DoubleIntegrator : public scrimmage::MotionModel {
 
     class Controller : public scrimmage::Controller {
      public:
-        virtual Eigen::Vector3d &u() = 0;
+        virtual Eigen::Vector4d &u() = 0;
     };
 
  protected:
     double update_dvdt(double vel, double acc);
-    Eigen::Vector3d ctrl_u_;
+    Eigen::Vector4d ctrl_u_;
     double max_vel_ = std::numeric_limits<double>::infinity();
     double max_acc_ = std::numeric_limits<double>::infinity();
     bool motion_model_sets_yaw_;

--- a/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegrator.h
+++ b/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegrator.h
@@ -53,6 +53,8 @@ class DoubleIntegrator : public scrimmage::MotionModel {
 
     virtual void model(const vector_t &x , vector_t &dxdt , double t);
 
+    void teleport(scrimmage::StatePtr &state);
+
     class Controller : public scrimmage::Controller {
      public:
         virtual Eigen::Vector3d &u() = 0;

--- a/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegrator.xml
+++ b/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegrator.xml
@@ -4,4 +4,5 @@
   <library>DoubleIntegrator_plugin</library>  
   <max_vel>1</max_vel>
   <max_acc>1</max_acc>
+  <motion_model_sets_yaw>true</motion_model_sets_yaw>
 </params>

--- a/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegratorControllerDirect/DoubleIntegratorControllerDirect.h
+++ b/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegratorControllerDirect/DoubleIntegratorControllerDirect.h
@@ -42,10 +42,10 @@ class DoubleIntegratorControllerDirect : public DoubleIntegrator::Controller {
  public:
     virtual void init(std::map<std::string, std::string> &params) {}
     virtual bool step(double t, double dt);
-    virtual Eigen::Vector3d &u() {return u_;}
+    virtual Eigen::Vector4d &u() {return u_;}
 
  protected:
-    Eigen::Vector3d u_;
+    Eigen::Vector4d u_;
 };
 
 #endif // INCLUDE_SCRIMMAGE_PLUGINS_MOTION_DOUBLEINTEGRATOR_DOUBLEINTEGRATORCONTROLLERDIRECT_DOUBLEINTEGRATORCONTROLLERDIRECT_H_

--- a/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegratorControllerWaypoint/DoubleIntegratorControllerWaypoint.h
+++ b/include/scrimmage/plugins/motion/DoubleIntegrator/DoubleIntegratorControllerWaypoint/DoubleIntegratorControllerWaypoint.h
@@ -42,10 +42,10 @@ class DoubleIntegratorControllerWaypoint : public DoubleIntegrator::Controller {
  public:
     virtual void init(std::map<std::string, std::string> &params);
     virtual bool step(double t, double dt);
-    virtual Eigen::Vector3d &u() {return u_;}
+    virtual Eigen::Vector4d &u() {return u_;}
 
  protected:
-    Eigen::Vector3d u_;
+    Eigen::Vector4d u_;
     Eigen::Vector2d gain_;
 };
 

--- a/src/plugins/motion/DoubleIntegrator/DoubleIntegrator.cpp
+++ b/src/plugins/motion/DoubleIntegrator/DoubleIntegrator.cpp
@@ -87,6 +87,10 @@ bool DoubleIntegrator::step(double t, double dt) {
             state_->quat().set(0, 0, atan2(x_[VY], x_[VX]));
         }
     }
+    else
+    {
+        state_->quat().set(0, 0, ctrl_u_(3));
+    }
     return true;
 }
 

--- a/src/plugins/motion/DoubleIntegrator/DoubleIntegrator.cpp
+++ b/src/plugins/motion/DoubleIntegrator/DoubleIntegrator.cpp
@@ -106,3 +106,13 @@ void DoubleIntegrator::model(const vector_t &x , vector_t &dxdt , double t) {
     dxdt[VY] = update_dvdt(x[VY], ctrl_u_(1));
     dxdt[VZ] = update_dvdt(x[VZ], ctrl_u_(2));
 }
+
+void DoubleIntegrator::teleport(scrimmage::StatePtr &state) {
+    x_[X] = state->pos()[0];
+    x_[Y] = state->pos()[1];
+    x_[Z] = state->pos()[2];
+    x_[VX] = state->vel()[0];
+    x_[VY] = state->vel()[1];
+    x_[VZ] = state->vel()[2];
+}
+

--- a/src/plugins/motion/DoubleIntegrator/DoubleIntegrator.cpp
+++ b/src/plugins/motion/DoubleIntegrator/DoubleIntegrator.cpp
@@ -53,6 +53,7 @@ bool DoubleIntegrator::init(std::map<std::string, std::string> &info,
                             std::map<std::string, std::string> &params) {
     max_vel_ = std::stod(params.at("max_vel"));
     max_acc_ = std::stod(params.at("max_acc"));
+    motion_model_sets_yaw_ = scrimmage::str2bool(params.at("motion_model_sets_yaw"));
 
     x_[X] = state_->pos()(0);
     x_[Y] = state_->pos()(1);
@@ -81,8 +82,10 @@ bool DoubleIntegrator::step(double t, double dt) {
 
     state_->pos() << x_[X], x_[Y], x_[Z];
     state_->vel() << x_[VX], x_[VY], x_[VZ];
-    if (x_[VY] != 0 || x_[VX] != 0) {
-        state_->quat().set(0, 0, atan2(x_[VY], x_[VX]));
+    if (motion_model_sets_yaw_) {
+        if (x_[VY] != 0 || x_[VX] != 0) {
+            state_->quat().set(0, 0, atan2(x_[VY], x_[VX]));
+        }
     }
     return true;
 }

--- a/src/plugins/motion/DoubleIntegrator/DoubleIntegratorControllerDirect/DoubleIntegratorControllerDirect.cpp
+++ b/src/plugins/motion/DoubleIntegrator/DoubleIntegratorControllerDirect/DoubleIntegratorControllerDirect.cpp
@@ -40,6 +40,7 @@ REGISTER_PLUGIN(scrimmage::Controller,
                 DoubleIntegratorControllerDirect_plugin)
 
 bool DoubleIntegratorControllerDirect::step(double t, double dt) {
-    u_ = desired_state_->vel();
+    u_.head(3) = desired_state_->vel();
+    u_(3) = desired_state_->quat().yaw();
     return true;
 }

--- a/src/plugins/motion/DoubleIntegrator/DoubleIntegratorControllerWaypoint/DoubleIntegratorControllerWaypoint.cpp
+++ b/src/plugins/motion/DoubleIntegrator/DoubleIntegratorControllerWaypoint/DoubleIntegratorControllerWaypoint.cpp
@@ -51,6 +51,6 @@ void DoubleIntegratorControllerWaypoint::init(std::map<std::string, std::string>
 }
 
 bool DoubleIntegratorControllerWaypoint::step(double t, double dt) {
-    u_ = -gain_(0) * (state_->pos() - desired_state_->pos()) - gain_(1) * state_->vel();
+    u_.head(3) = -gain_(0) * (state_->pos() - desired_state_->pos()) - gain_(1) * state_->vel();
     return true;
 }


### PR DESCRIPTION
This modification allows yaw to be set in desired_state_ in autonomy plugin, and includes a parameter in DoubleIntegrator that determines whether the motion model sets the yaw based on velocity or sets it based on whatever is specified in desired_state_->quat().yaw(). Also adds teleportation functionality to DoubleIntegrator. 