### PR TITLE
include unordered_map to fix compile err

### DIFF
--- a/include/scrimmage/plugin_manager/Plugin.h
+++ b/include/scrimmage/plugin_manager/Plugin.h
@@ -38,6 +38,7 @@
 #include <scrimmage/pubsub/Subscriber.h>
 
 #include <unordered_set>
+#include <unordered_map>
 #include <memory>
 #include <map>
 #include <list>


### PR DESCRIPTION
Didn't see this error on Travis, but I had a local compile error due to unordered_map not being included in Plugin.h. Adding that include fixed it for me.