### PR TITLE
Initialize scores so they aren't mysteriously blank...

### DIFF
--- a/include/scrimmage/plugins/metrics/SimpleCaptureMetrics/SimpleCaptureMetrics.h
+++ b/include/scrimmage/plugins/metrics/SimpleCaptureMetrics/SimpleCaptureMetrics.h
@@ -36,6 +36,7 @@
 #include <scrimmage/metrics/Metrics.h>
 
 #include <iostream>
+#include <set>
 #include <map>
 #include <string>
 
@@ -120,6 +121,8 @@ class SimpleCaptureMetrics : public scrimmage::Metrics {
  protected:
     std::map<int, Score> scores_;
     std::map<int, Score> team_scores_map_;
+    bool initialized_ = false;
+    std::set<int> teams_;
 
     std::map<std::string, std::string> params_;
 };


### PR DESCRIPTION
when they should be zero. Should make processing summary.csv files easier since row count will be predictable even if one or more teams don't score. 