### PR TITLE
make gps/euclidean conversions easier

### DIFF
--- a/include/scrimmage/math/Angles.h
+++ b/include/scrimmage/math/Angles.h
@@ -36,6 +36,11 @@
 namespace scrimmage {
 class Angles {
  public:
+    Angles();
+
+    enum class Type {GPS, EUCLIDEAN};
+    Angles(double angle, Type input_type, Type output_type);
+
     enum class Rotate {
         CCW = 0,
         CW

--- a/src/log/FrameUpdateClient.cpp
+++ b/src/log/FrameUpdateClient.cpp
@@ -37,6 +37,7 @@
 
 #include <scrimmage/log/FrameUpdateClient.h>
 #include <scrimmage/common/Utilities.h>
+#include <scrimmage/math/Angles.h>
 #include <scrimmage/math/Quaternion.h>
 
 #include <iostream>
@@ -55,12 +56,9 @@ using std::cout;
 using std::endl;
 
 namespace scrimmage {
-FrameUpdateClient::FrameUpdateClient(const std::string &ip, int port) {
-    angles_to_gps_.set_input_clock_direction(Angles::Rotate::CCW);
-    angles_to_gps_.set_input_zero_axis(Angles::HeadingZero::Pos_X);
-    angles_to_gps_.set_output_clock_direction(Angles::Rotate::CW);
-    angles_to_gps_.set_output_zero_axis(Angles::HeadingZero::Pos_Y);
-}
+
+FrameUpdateClient::FrameUpdateClient(const std::string &ip, int port) :
+    angles_to_gps_(0, Angles::Type::EUCLIDEAN, Angles::Type::GPS) {}
 
 bool FrameUpdateClient::send_frame(scrimmage_proto::Frame &frame) {
 

--- a/src/math/Angles.cpp
+++ b/src/math/Angles.cpp
@@ -38,6 +38,29 @@
 
 namespace scrimmage {
 
+Angles::Angles() {}
+
+Angles::Angles(double angle, Type input_type, Type output_type) {
+
+    if (input_type == Type::GPS) {
+        in_zero_ = HeadingZero::Pos_Y;
+        in_direction_ = Rotate::CW;
+    } else if (input_type == Type::EUCLIDEAN) {
+        in_zero_ = HeadingZero::Pos_X;
+        in_direction_ = Rotate::CCW;
+    }
+
+    if (output_type == Type::GPS) {
+        out_zero_ = HeadingZero::Pos_Y;
+        out_direction_ = Rotate::CW;
+    } else if (output_type == Type::EUCLIDEAN) {
+        out_zero_ = HeadingZero::Pos_X;
+        out_direction_ = Rotate::CCW;
+    }
+
+    set_angle(angle);
+}
+
 double Angles::deg2rad(double deg) {return deg * M_PI / 180.0;}
 
 double Angles::rad2deg(double rad) {return rad * 180.0 / M_PI;}

--- a/src/plugins/autonomy/ArduPilot/ArduPilot.cpp
+++ b/src/plugins/autonomy/ArduPilot/ArduPilot.cpp
@@ -65,19 +65,15 @@ REGISTER_PLUGIN(scrimmage::Autonomy,
 namespace scrimmage {
 namespace autonomy {
 
-ArduPilot::ArduPilot()
-    : to_ardupilot_ip_("127.0.0.1")
-    , to_ardupilot_port_("5003")
-    , from_ardupilot_port_(5002) {
+ArduPilot::ArduPilot() :
+    to_ardupilot_ip_("127.0.0.1"),
+    to_ardupilot_port_("5003"),
+    angles_to_gps_(0, Angles::Type::EUCLIDEAN, Angles::Type::GPS),
+    from_ardupilot_port_(5002) {
 
     for (int i = 0; i < MAX_NUM_SERVOS; i++) {
         servo_pkt_.servos[i] = 0;
     }
-
-    angles_to_gps_.set_input_clock_direction(sc::Angles::Rotate::CCW);
-    angles_to_gps_.set_input_zero_axis(sc::Angles::HeadingZero::Pos_X);
-    angles_to_gps_.set_output_clock_direction(sc::Angles::Rotate::CW);
-    angles_to_gps_.set_output_zero_axis(sc::Angles::HeadingZero::Pos_Y);
 }
 
 void ArduPilot::init(std::map<std::string, std::string> &params) {

--- a/src/plugins/autonomy/MultirotorTests/MultirotorTests.cpp
+++ b/src/plugins/autonomy/MultirotorTests/MultirotorTests.cpp
@@ -56,12 +56,8 @@ REGISTER_PLUGIN(scrimmage::Autonomy,
 namespace scrimmage {
 namespace autonomy {
 
-MultirotorTests::MultirotorTests() {
-    angles_to_gps_.set_input_clock_direction(sc::Angles::Rotate::CCW);
-    angles_to_gps_.set_input_zero_axis(sc::Angles::HeadingZero::Pos_X);
-    angles_to_gps_.set_output_clock_direction(sc::Angles::Rotate::CW);
-    angles_to_gps_.set_output_zero_axis(sc::Angles::HeadingZero::Pos_Y);
-}
+MultirotorTests::MultirotorTests() :
+    angles_to_gps_(0, Angles::Type::EUCLIDEAN, Angles::Type::GPS) {}
 
 void MultirotorTests::init(std::map<std::string, std::string> &params) {
     multirotor_ = std::dynamic_pointer_cast<sc::motion::Multirotor>(parent_->motion());

--- a/src/plugins/motion/JSBSimModel/JSBSimModel.cpp
+++ b/src/plugins/motion/JSBSimModel/JSBSimModel.cpp
@@ -62,15 +62,8 @@ std::tuple<int, int, int> JSBSimModel::version() {
 
 bool JSBSimModel::init(std::map<std::string, std::string> &info,
                        std::map<std::string, std::string> &params) {
-    angles_from_jsbsim_.set_input_clock_direction(ang::Rotate::CW);
-    angles_from_jsbsim_.set_input_zero_axis(ang::HeadingZero::Pos_Y);
-    angles_from_jsbsim_.set_output_clock_direction(ang::Rotate::CCW);
-    angles_from_jsbsim_.set_output_zero_axis(ang::HeadingZero::Pos_X);
-
-    angles_to_jsbsim_.set_input_clock_direction(ang::Rotate::CCW);
-    angles_to_jsbsim_.set_input_zero_axis(ang::HeadingZero::Pos_X);
-    angles_to_jsbsim_.set_output_clock_direction(ang::Rotate::CW);
-    angles_to_jsbsim_.set_output_zero_axis(ang::HeadingZero::Pos_Y);
+    angles_from_jsbsim_ = Angles(0, Angles::Type::GPS, Angles::Type::EUCLIDEAN);
+    angles_to_jsbsim_ = Angles(0, Angles::Type::EUCLIDEAN, Angles::Type::GPS);
 
     use_pitch_ = str2bool(params.at("use_pitch"));
     std::string z_name =  use_pitch_ ?

--- a/test/test_angles.cpp
+++ b/test/test_angles.cpp
@@ -31,6 +31,8 @@
  */
 
 #include <gtest/gtest.h>
+
+#include <scrimmage/common/Utilities.h>
 #include <scrimmage/math/Angles.h>
 
 #include <cmath>
@@ -73,4 +75,46 @@ TEST(test_angles, angle_within) {
             EXPECT_FALSE(ang::angle_within(high_rad + M_PI, high_rad + M_PI / 2, ang_rad));
         }
     }
+}
+
+TEST(test_angles, gps_to_euclidean) {
+    using sc::Angles;
+    using Type = Angles::Type;
+
+    Angles beg_angle(0, Type::GPS, Type::EUCLIDEAN);
+    Angles end_angle(240, Type::GPS, Angles::Type::EUCLIDEAN);
+
+    const double eps = 1e-6;
+    EXPECT_NEAR(beg_angle.angle(), 90, eps);
+    EXPECT_NEAR(end_angle.angle(), 210, eps);
+
+    // test interpolation (clockwise)
+    std::vector<double> angles = sc::linspace(beg_angle.angle(), end_angle.angle(), 3);
+    EXPECT_EQ(angles.size(), static_cast<size_t>(3));
+    if (angles.size() != 3) return;
+
+    EXPECT_NEAR(angles[0], 90, eps);
+    EXPECT_NEAR(angles[1], 150, eps);
+    EXPECT_NEAR(angles[2], 210, eps);
+
+    // now test interpolation (counter-clockwise)
+    angles = sc::linspace(beg_angle.angle(), end_angle.angle() - 360, 3);
+    EXPECT_EQ(angles.size(), static_cast<size_t>(3));
+    if (angles.size() != 3) return;
+
+    EXPECT_NEAR(angles[0], 90, eps);
+    EXPECT_NEAR(angles[1], -30, eps);
+    EXPECT_NEAR(angles[2], -150, eps);
+}
+
+TEST(test_angles, euclidean_to_gps) {
+    using sc::Angles;
+    using Type = Angles::Type;
+
+    Angles beg_angle(0, Type::EUCLIDEAN, Type::GPS);
+    Angles end_angle(240, Type::EUCLIDEAN, Angles::Type::GPS);
+
+    const double eps = 1e-6;
+    EXPECT_NEAR(beg_angle.angle(), 90, eps);
+    EXPECT_NEAR(end_angle.angle(), 210, eps);
 }


### PR DESCRIPTION
it is common to use the ``Angles`` class to convert between gps and euclidean coordinates. This pull request adds a constructor to that class to faciliate this initialization.