### PR TITLE
More realistic ContactBlobCamera sensor plugin

### DIFF
--- a/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCamera.h
+++ b/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCamera.h
@@ -58,10 +58,18 @@ class ContactBlobCamera : public scrimmage::Sensor {
 
     Eigen::Vector2d project_rel_3d_to_2d(Eigen::Vector3d rel_pos);
     bool in_field_of_view(Eigen::Vector3d rel_pos);
+    void draw_object_with_bounding_box(cv::Mat frame, cv::Rect rect,
+                                       Eigen::Vector2d center, double radius);
 
     double max_detect_range_;
     double az_thresh_;
     double el_thresh_;
+
+    double fn_prob_;
+    double fp_prob_;
+    int max_false_positives_;
+    int std_dev_w_;
+    int std_dev_h_;
 
     int img_width_;
     int img_height_;

--- a/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCamera.xml
+++ b/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCamera.xml
@@ -9,19 +9,26 @@
   <focal_length>0.035</focal_length>
 
   <frames_per_second>20</frames_per_second>
-  
+
   <max_detect_range>2000</max_detect_range> <!-- meters -->
   <azimuth_fov>45</azimuth_fov>             <!-- degrees -->
   <elevation_fov>45</elevation_fov>         <!-- degrees -->
-  
+
+  <!-- noise in object detection -->
+  <false_negative_probability>0.1</false_negative_probability> <!-- value between 0 and 1 -->
+  <false_positive_probability>0.1</false_positive_probability> <!-- value between 0 and 1 -->
+  <max_false_positives_per_frame>10</max_false_positives_per_frame>
+  <std_dev_width>10</std_dev_width> <!-- value less than img_width -->
+  <std_dev_height>10</std_dev_height> <!-- value less than img_height -->
+
   <!-- noise params are defined with (mean, standard deviation) -->
   <pos_noise_0>0.0 1.0</pos_noise_0> <!-- x position noise (2D image) -->
-  <pos_noise_1>0.0 1.0</pos_noise_1> <!-- y position noise (2D image)-->  
+  <pos_noise_1>0.0 1.0</pos_noise_1> <!-- y position noise (2D image)-->
 
   <!-- not used -->
   <!-- <pos_noise_2>0.0 1.0</pos_noise_2> --> <!-- z position noise -->
   <!-- <orient_noise_0>0.0 0.0</orient_noise_0> --> <!-- roll noise (rad) -->
   <!-- <orient_noise_1>0.0 0.0</orient_noise_1> --> <!-- pitch noise (rad) -->
-  <!-- <orient_noise_2>0.0 0.0</orient_noise_2> --> <!-- yaw noise (rad) -->  
-  
+  <!-- <orient_noise_2>0.0 0.0</orient_noise_2> --> <!-- yaw noise (rad) -->
+
 </params>

--- a/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCameraNoNoise.xml
+++ b/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCameraNoNoise.xml
@@ -9,19 +9,26 @@
   <focal_length>0.035</focal_length>
 
   <frames_per_second>20</frames_per_second>
-  
+
   <max_detect_range>2000</max_detect_range> <!-- meters -->
   <azimuth_fov>45</azimuth_fov>             <!-- degrees -->
   <elevation_fov>45</elevation_fov>         <!-- degrees -->
-  
+
+  <!-- noise in object detection -->
+  <false_negative_probability>0</false_negative_probability> <!-- value between 0 and 1 -->
+  <false_positive_probability>0</false_positive_probability> <!-- value between 0 and 1 -->
+  <max_false_positives_per_frame>0</max_false_positives_per_frame>
+  <std_dev_width>10</std_dev_width> <!-- value less than img_width -->
+  <std_dev_height>10</std_dev_height> <!-- value less than img_height -->
+
   <!-- noise params are defined with (mean, standard deviation) -->
   <pos_noise_0>0.0 0.0</pos_noise_0> <!-- x position noise (2D image) -->
-  <pos_noise_1>0.0 0.0</pos_noise_1> <!-- y position noise (2D image)-->  
+  <pos_noise_1>0.0 0.0</pos_noise_1> <!-- y position noise (2D image)-->
 
   <!-- not used -->
   <!-- <pos_noise_2>0.0 1.0</pos_noise_2> --> <!-- z position noise -->
   <!-- <orient_noise_0>0.0 0.0</orient_noise_0> --> <!-- roll noise (rad) -->
   <!-- <orient_noise_1>0.0 0.0</orient_noise_1> --> <!-- pitch noise (rad) -->
-  <!-- <orient_noise_2>0.0 0.0</orient_noise_2> --> <!-- yaw noise (rad) -->  
-  
+  <!-- <orient_noise_2>0.0 0.0</orient_noise_2> --> <!-- yaw noise (rad) -->
+
 </params>

--- a/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCameraType.h
+++ b/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCameraType.h
@@ -34,6 +34,7 @@
 #define INCLUDE_SCRIMMAGE_PLUGINS_SENSOR_CONTACTBLOBCAMERA_CONTACTBLOBCAMERATYPE_H_
 
 #include <map>
+#include <vector>
 #include <opencv2/core/core.hpp>
 
 namespace scrimmage {
@@ -41,7 +42,7 @@ namespace sensor {
 class ContactBlobCameraType {
  public:
     cv::Mat frame;
-    std::map<int, cv::Rect> bounding_boxes;
+    std::map<int, std::vector<cv::Rect>> bounding_boxes;
 };
 } // namespace sensor
 } // namespace scrimmage


### PR DESCRIPTION
ContactBlobCamera sensor plugin now considers false positives and false negatives.

- **False negatives**:
User specifies the false negative probability. For each detection, the plugin generates a random number between 0 and 1. If it's less than the set probability, then the detected bounding box is skipped to simulate a false negative.

- **False positives**:
User specifies the false positive probability and the maximum number of false positives (N) any given frame can have. For each detection, the plugin generates N random numbers between 0 and 1. The instances that yield a value less than the set probability will be considered as a false positive. For the current frame, a bounding box will be added centered at random pixel coordinates.