### PR TITLE
removed vestigial cuas code from cmake project template; updated gtes…

### DIFF
--- a/scripts/templates/cmake-project/CMakeLists.txt
+++ b/scripts/templates/cmake-project/CMakeLists.txt
@@ -42,6 +42,7 @@ get_filename_component(PROJECT_MODULES_DIR ./cmake/Modules ABSOLUTE)
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_MODULES_DIR})
 
 include(MacroSubDirList)
+include(MacroAddExternalTarget)
 
 if(NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING
@@ -192,59 +193,46 @@ if (NOT DEFINED CMAKE_TOOLCHAIN_FILE AND BUILD_TESTS)
   enable_testing()
   
   if (BUILD_GTEST)
-    ########################################################
-    # Download and build googletest
-    ########################################################
-    include(ExternalProject)
-    set(EXTERNAL_PROJECT_GTEST googletest)
-    ExternalProject_Add (
-      ${EXTERNAL_PROJECT_GTEST} 
-      PREFIX ${CMAKE_CURRENT_BINARY_DIR}/3rd-party
-      CMAKE_COMMAND cmake -DBUILD_SHARED_LIBS=ON -DCMAKE_INSTALL_PREFIX=${CMAKE_CURRENT_BINARY_DIR}/3rd-party ..
-      GIT_REPOSITORY "https://github.com/google/googletest.git"
-      PATCH_COMMAND ""
-      UPDATE_COMMAND ""
-      INSTALL_COMMAND make install
-      )
+    ############################################################
+    # https://github.com/google/googletest/tree/master/googletest#incorporating-into-an-existing-cmake-project
+    ############################################################
 
-    ExternalProject_Get_Property(${EXTERNAL_PROJECT_GTEST} install_dir)
-    set(GTEST_INCLUDE_DIRS ${install_dir}/include)
-    set(GMOCK_INCLUDE_DIRS ${install_dir}/include)
-    
-    set(GTEST_LIBRARIES
-      ${install_dir}/lib/libgtest.so
-      )
-    set(GTEST_MAIN_LIBRARIES
-      ${install_dir}/lib/libgtest_main.so
-      )
-    set(GTEST_BOTH_LIBRARIES
-      ${GTEST_LIBRARIES}
-      ${GTEST_MAIN_LIBRARIES}
-      )
+    # Download and unpack googletest at configure time
+    if (NOT TARGET gtest_main)
+        configure_file(${CMAKE_SOURCE_DIR}/cmake/Modules/CMakeLists.txt.gtest.in
+          googletest-download/CMakeLists.txt)
+        execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+          RESULT_VARIABLE result
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+        if(result)
+          message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+        endif()
+        execute_process(COMMAND ${CMAKE_COMMAND} --build .
+          RESULT_VARIABLE result
+          WORKING_DIRECTORY ${CMAKE_BINARY_DIR}/googletest-download )
+        if(result)
+          message(FATAL_ERROR "Build step for googletest failed: ${result}")
+        endif()
 
-    set(GMOCK_LIBRARIES
-      ${install_dir}/lib/libgmock.so
-      )
-    set(GMOCK_MAIN_LIBRARIES
-      ${install_dir}/lib/libgmock_main.so
-      )
-    set(GMOCK_BOTH_LIBRARIES
-      ${GMOCK_LIBRARIES}
-      ${GMOCK_MAIN_LIBRARIES}
-      )    
-  else()
-    ########################################################
-    # Find GTest
-    ########################################################
-    set(EXTERNAL_PROJECT_GTEST "")
-    find_package (GTest REQUIRED)
-    find_package (GMock REQUIRED)
+        # Prevent overriding the parent project's compiler/linker
+        # settings on Windows
+        set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+        # Add googletest directly to our build. This defines
+        # the gtest and gtest_main targets.
+        add_subdirectory(${CMAKE_BINARY_DIR}/googletest-src
+                         ${CMAKE_BINARY_DIR}/googletest-build)
+
+        # The gtest/gtest_main targets carry header search path
+        # dependencies automatically when using CMake 2.8.11 or
+        # later. Otherwise we have to add them here ourselves.
+        if (CMAKE_VERSION VERSION_LESS 2.8.11)
+          include_directories("${gtest_SOURCE_DIR}/include")
+        endif()
+      endif()
   endif()
-  
-  include_directories(${GTEST_INCLUDE_DIRS})
-  include_directories(${GMOCK_INCLUDE_DIRS})
 
-  add_subdirectory(test)  
+  add_subdirectory(test)
 endif()
 
 # Add a distclean target to the Makefile

--- a/scripts/templates/cmake-project/cmake/Modules/MacroAddExternalTarget.cmake
+++ b/scripts/templates/cmake-project/cmake/Modules/MacroAddExternalTarget.cmake
@@ -1,0 +1,11 @@
+macro(AddExternalTarget _VARS)
+  set(LST ${ARGV})
+  list(GET LST 0 TGT)
+  list(REMOVE_AT LST 0)
+
+  foreach(EXT_TGT ${LST})
+    if (${EXT_TGT})
+      add_dependencies(${TGT} ${${EXT_TGT}})
+    endif()
+  endforeach()
+endmacro()

--- a/scripts/templates/cmake-project/cmake/Modules/project-config.cmake.in
+++ b/scripts/templates/cmake-project/cmake/Modules/project-config.cmake.in
@@ -1,7 +1,7 @@
 # - Config file for the FooBar package
 # It defines the following variables
-#  SCRIMMAGE_CUAS_INCLUDE_DIRS - include directories for FooBar
-#  SCRIMMAGE_CUAS_LIBRARIES    - libraries to link against
+#  >>>PROJECT_NAME<<<_INCLUDE_DIRS - include directories for FooBar
+#  >>>PROJECT_NAME<<<_LIBRARIES    - libraries to link against
 
 # Compute paths
 get_filename_component(PROJECT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
@@ -9,5 +9,5 @@ get_filename_component(PROJECT_CMAKE_DIR "${CMAKE_CURRENT_LIST_FILE}" PATH)
 ## Our library dependencies (contains definitions for IMPORTED targets)
 include("${PROJECT_CMAKE_DIR}/@PROJECT_NAME@-targets.cmake")
 
-set(SCRIMMAGE_CUAS_INCLUDE_DIRS "@PROJECT_INCLUDE_DIRS@")
-set(SCRIMMAGE_CUAS_LIBRARIES "@PROJECT_LIBS@")
+set((>>>PROJECT_NAME<<<)_INCLUDE_DIRS "@PROJECT_INCLUDE_DIRS@")
+set((>>>PROJECT_NAME<<<)_LIBRARIES "@PROJECT_LIBS@")

--- a/scripts/templates/cmake-project/test/CMakeLists.txt
+++ b/scripts/templates/cmake-project/test/CMakeLists.txt
@@ -3,9 +3,10 @@ foreach(test_file ${test_files})
   get_filename_component(test_name ${test_file} NAME_WE)
   add_executable(${test_name} ${test_file})
   add_dependencies(${test_name} scrimmage)
+  AddExternalTarget(${test_name} EXTERNAL_PROJECT_GTEST )
   target_link_libraries(${test_name}
-    ${GTEST_BOTH_LIBRARIES}
-    ${GMOCK_BOTH_LIBRARIES}
+    gtest_main
+    gmock_main
     scrimmage
     ${PYTHON_LIBRARIES}
     )


### PR DESCRIPTION
…t to be added externally so template project tests build properly and gtest is linked as a target and not with variables