### PR TITLE
Don't require scrimmage.bindings with import scrimmage, don't import …

### DIFF
--- a/python/scrimmage/__init__.py
+++ b/python/scrimmage/__init__.py
@@ -29,7 +29,10 @@
 # A Long description goes here.
 #
 #
-from scrimmage.bindings import *
+try:
+    from scrimmage.bindings import *
+except ImportError:
+    print('Unable to import scrimmage.bindings.')
 from scrimmage.utils import *
 try:
     from scrimmage.external_control import ScrimmageEnv

--- a/scripts/generate_scenarios.py
+++ b/scripts/generate_scenarios.py
@@ -42,7 +42,7 @@ import pandas as pd
 import sys
 import errno
 import shutil
-import scrimmage
+import scrimmage.utils as utils
 
 # If you get warnings about fc-list, remove font cache:
 # rm -rf ~/.cache/matplotlib/
@@ -225,7 +225,7 @@ def main():
             shutil.copyfile(TEMP_MISSION_FILE, mission_dir+"/"+str(i+1)+".xml")
 
     if not args.only_xml:
-        scrimmage.qsub(args.num_runs, mission_dir, args.nodes)
+        utils.qsub(args.num_runs, mission_dir, args.nodes)
 
     os.remove(TEMP_MISSION_FILE)
     return 0


### PR DESCRIPTION
Since generate_scenarios only needs scrimmage.util, and only qsub from that, I tweaked generate_scenarios's imports, as well as added a try-except in \_\_init\_\_.py for less error-happy import situations in the future.