### PR TITLE
removed find_dependency call in project-config.cmake that was causing…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,12 @@ include_directories(${EIGEN3_INCLUDE_DIR})
 #set(Boost_DEBUG ON)
 find_package(Boost 1.55 COMPONENTS thread date_time iostreams program_options regex
   filesystem system graph REQUIRED)
+add_library(scrimmage-boost INTERFACE)
+target_include_directories(scrimmage-boost INTERFACE ${Boost_INCLUDE_DIRS})
+target_link_libraries(scrimmage-boost INTERFACE ${Boost_LIBRARIES})
+install(TARGETS scrimmage-boost
+  EXPORT ${PROJECT_NAME}-targets
+)
 
 ########################################################
 # Find OpenCV
@@ -352,7 +358,7 @@ if (UNIX AND NOT APPLE)
     )
 
   # Add all library targets to the build-tree export set
-  export(TARGETS ${PROJECT_LIBS} ${PROJECT_PLUGINS}
+  export(TARGETS ${PROJECT_LIBS} ${PROJECT_PLUGINS} scrimmage-boost
     FILE "${CMAKE_BINARY_DIR}/${PROJECT_NAME}-targets.cmake")
 
   # Export the package for use from the build-tree

--- a/cmake/Modules/project-config.cmake.in
+++ b/cmake/Modules/project-config.cmake.in
@@ -11,16 +11,6 @@ set(SCRIMMAGE_INCLUDE_DIRS ${SCRIMMAGE_INCLUDE_DIR}
   @TMP_MSGS_INCLUDE_DIR@
   @TMP_PROTO_INCLUDE_DIR@)
 
-# include dependencies BEFORE including scrimmage-targets.cmake
-include(CMakeFindDependencyMacro)
-find_dependency(Eigen3 REQUIRED)
-find_dependency(Protobuf REQUIRED)
-
-#find_dependency(Boost REQUIRED)
-# FIXME this should not be needed, but for some reason downstream projects can't find boost's targets
-# without this line; this might be a bug with find_dependency
-find_package(Boost 1.55 REQUIRED COMPONENTS thread date_time iostreams program_options regex filesystem system graph)
-
 if(NOT TARGET scrimmage)
   include("${CMAKE_CURRENT_LIST_DIR}/scrimmage-targets.cmake")
 endif()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -36,7 +36,6 @@ ADD_LIBRARY( ${LIBRARY_NAME} SHARED
 
 add_dependencies(${LIBRARY_NAME}
   scrimmage scrimmage-msgs scrimmage-proto-gen
-  Boost::boost
   )
 
 #find_package (Eigen3 3.3 REQUIRED NO_MODULE)
@@ -45,18 +44,16 @@ target_link_libraries(${LIBRARY_NAME}
   PUBLIC
     scrimmage-protos
     scrimmage-msgs
-    # TODO the cmake documentation says the Boost::boost target
-    # should include all the header-only libraries, but doesn't
-    # seem to work
+    ${PYTHON_LIBRARIES}
+    ${GeographicLib_LIBRARIES}
+    ${CMAKE_DL_LIBS}
+  PRIVATE
     Boost::boost
     Boost::filesystem
     Boost::program_options
     Boost::date_time
     Boost::graph
     Boost::thread
-    ${PYTHON_LIBRARIES}
-    ${GeographicLib_LIBRARIES}
-    ${CMAKE_DL_LIBS}
 )
 
 SET (_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})

--- a/src/viewer/CMakeLists.txt
+++ b/src/viewer/CMakeLists.txt
@@ -17,11 +17,13 @@ if(VTK_LIBRARIES)
   target_link_libraries(${LIBRARY_NAME}
     scrimmage
     scrimmage-protos
+    scrimmage-boost
     ${VTK_LIBRARIES})
 else()
   target_link_libraries(${LIBRARY_NAME}
     scrimmage
     scrimmage-protos
+    scrimmage-boost
     vtkHybrid
     vtkWidgets)
 endif()


### PR DESCRIPTION
… issues in gtri-uav; moved boost dependency to private scope; added scrimmage-boost target for export