### PR TITLE
fix linking errors when python is disabled

### DIFF
--- a/share/scrimmage/CMakeLists.txt
+++ b/share/scrimmage/CMakeLists.txt
@@ -11,10 +11,13 @@ target_link_libraries(${APP_NAME}
   ${JSBSIM_LIBRARIES}
   scrimmage-core
   scrimmage-boost
-  scrimmage-python
   ${SWARM_SIM_LIBS}
   dl
   )
+if (ENABLE_PYTHON_BINDINGS)
+  target_link_libraries(${APP_NAME} scrimmage-python)
+endif()
+
 
 if (NOT EXTERNAL AND ${VTK_FOUND})
   target_link_libraries(${APP_NAME}

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -7,8 +7,11 @@ foreach(test_file ${test_files})
   target_link_libraries(${test_name}
     gtest_main
     scrimmage-core
-    scrimmage-python
     ${PROJECT_PLUGINS}
     )
+  if (ENABLE_PYTHON_BINDINGS)
+    target_link_libraries(${test_name} scrimmage-python)
+  endif()
+
   add_test(NAME ${test_name} COMMAND ${test_name})
 endforeach()

--- a/tools/aggregate-runs/CMakeLists.txt
+++ b/tools/aggregate-runs/CMakeLists.txt
@@ -11,8 +11,10 @@ target_link_libraries(${APP_NAME}
   ${SWARM_SIM_LIBS}
   scrimmage-core
   scrimmage-boost
-  scrimmage-python
   )
+if (ENABLE_PYTHON_BINDINGS)
+  target_link_libraries(${APP_NAME} scrimmage-python)
+endif()
 
 # Link executable to other libraries
 #target_link_libraries(${APP_NAME})

--- a/tools/filter-runs/CMakeLists.txt
+++ b/tools/filter-runs/CMakeLists.txt
@@ -10,8 +10,10 @@ add_dependencies(${APP_NAME} scrimmage-protos)
 target_link_libraries(${APP_NAME}
   scrimmage-core
   scrimmage-boost
-  scrimmage-python
   )
+if (ENABLE_PYTHON_BINDINGS)
+  target_link_libraries(${APP_NAME} scrimmage-python)
+endif()
 
 # Link executable to other libraries
 #target_link_libraries(${APP_NAME})

--- a/tools/scrimmage-plugin/CMakeLists.txt
+++ b/tools/scrimmage-plugin/CMakeLists.txt
@@ -9,9 +9,11 @@ target_link_libraries(${APP_NAME}
   ${JSBSIM_LIBRARIES}
   scrimmage-core
   scrimmage-boost
-  scrimmage-python
   dl
   )
+if (ENABLE_PYTHON_BINDINGS)
+  target_link_libraries(${APP_NAME} scrimmage-python)
+endif()
 
 ##--------------------------------------------------------
 ## Library Creation


### PR DESCRIPTION
Fixed an issue with previous merge that would cause cmake errors when python was disabled. This error didn't appear before because target_link_libraries() does not throw an error when linked against an empty string, which would have instead potentially caused cryptic errors at runtime. Now scrimmage will never link to empty library strings.