### PR TITLE
Fixed segfault from CPA.cpp

### DIFF
--- a/src/plugins/metrics/CPA/CPA.cpp
+++ b/src/plugins/metrics/CPA/CPA.cpp
@@ -86,12 +86,14 @@ bool CPA::step_metrics(double t, double dt) {
     for (auto &kv : *id_to_ent_map_) {
         for (auto &kv2 : *id_to_ent_map_) {
             if (kv != kv2) {
-                double cur_distance = (kv.second->state()->pos() -
-                        kv2.second->state()->pos()).norm();
-                if (cur_distance < cpa_map_[kv.first].distance()) {
-                    cpa_map_[kv.first].set_distance(cur_distance);
-                    cpa_map_[kv.first].set_closest_entity(kv2.first);
-                    cpa_map_[kv.first].set_time(t);
+                if (kv.second->state() && kv2.second->state()) {
+                    double cur_distance = (kv.second->state()->pos() -
+                            kv2.second->state()->pos()).norm();
+                    if (cur_distance < cpa_map_[kv.first].distance()) {
+                        cpa_map_[kv.first].set_distance(cur_distance);
+                        cpa_map_[kv.first].set_closest_entity(kv2.first);
+                        cpa_map_[kv.first].set_time(t);
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fixed error with a Segfault happening in CPA.cpp - in the case that an entity was destroyed, we were still attempting to access their state which was a shared pointer to empty