### PR TITLE
style updates

### DIFF
--- a/include/scrimmage/parse/ConfigParse.h
+++ b/include/scrimmage/parse/ConfigParse.h
@@ -67,7 +67,7 @@ class ConfigParse {
     void recursive_params(rapidxml::xml_node<char> *root,
         std::map<std::string, std::string> &overrides,
         std::map<std::string, std::string> &params,
-        std::string prev);
+        const std::string &prev);
 };
 } // namespace scrimmage
 #endif // INCLUDE_SCRIMMAGE_PARSE_CONFIGPARSE_H_

--- a/include/scrimmage/plugins/autonomy/BoundaryDefense/BoundaryDefense.h
+++ b/include/scrimmage/plugins/autonomy/BoundaryDefense/BoundaryDefense.h
@@ -41,20 +41,18 @@
 #include <map>
 #include <utility>
 
-namespace sci = scrimmage::interaction;
-
 namespace scrimmage {
 namespace autonomy {
 class BoundaryDefense : public scrimmage::Autonomy {
  public:
     BoundaryDefense();
-    virtual void init(std::map<std::string, std::string> &params);
-    virtual bool step_autonomy(double t, double dt);
+    void init(std::map<std::string, std::string> &params) override;
+    bool step_autonomy(double t, double dt) override;
 
  protected:
     int boundary_id_ = -1;
-    std::map<int, std::pair<sci::BoundaryInfo,
-        std::shared_ptr<sci::BoundaryBase>>> boundaries_;
+    std::map<int, std::pair<interaction::BoundaryInfo,
+        std::shared_ptr<interaction::BoundaryBase>>> boundaries_;
 
     scrimmage::PublisherPtr pub_wp_list_;
     void publish_waypoint(const Eigen::Vector3d &point);

--- a/include/scrimmage/plugins/autonomy/CommandStringRelay/CommandStringRelay.h
+++ b/include/scrimmage/plugins/autonomy/CommandStringRelay/CommandStringRelay.h
@@ -42,8 +42,8 @@ namespace autonomy {
 class CommandStringRelay : public scrimmage::Autonomy {
  public:
     CommandStringRelay();
-    virtual void init(std::map<std::string, std::string> &params);
-    virtual bool step_autonomy(double t, double dt);
+    void init(std::map<std::string, std::string> &params) override;
+    bool step_autonomy(double t, double dt) override;
 
  protected:
     std::map<std::string, scrimmage::PublisherPtr> pubs_;

--- a/include/scrimmage/plugins/autonomy/TakeFlag/TakeFlag.h
+++ b/include/scrimmage/plugins/autonomy/TakeFlag/TakeFlag.h
@@ -35,22 +35,23 @@
 #include <scrimmage/autonomy/Autonomy.h>
 
 #include <scrimmage/plugins/interaction/Boundary/BoundaryInfo.h>
-#include <scrimmage/plugins/interaction/Boundary/BoundaryBase.h>
 
 #include <string>
 #include <map>
 #include <utility>
 
-namespace sc = scrimmage;
-namespace sci = scrimmage::interaction;
-
 namespace scrimmage {
+
+namespace interaction {
+class BoundaryBase;
+}
+
 namespace autonomy {
 class TakeFlag : public scrimmage::Autonomy {
  public:
     TakeFlag();
-    virtual void init(std::map<std::string, std::string> &params);
-    virtual bool step_autonomy(double t, double dt);
+    void init(std::map<std::string, std::string> &params) override;
+    bool step_autonomy(double t, double dt) override;
 
  protected:
     int flag_boundary_id_ = -1;
@@ -58,8 +59,8 @@ class TakeFlag : public scrimmage::Autonomy {
 
     scrimmage::PublisherPtr pub_wp_list_;
 
-    std::map<int, std::pair<sci::BoundaryInfo,
-        std::shared_ptr<sci::BoundaryBase>>> boundaries_;
+    std::map<int, std::pair<interaction::BoundaryInfo,
+        std::shared_ptr<interaction::BoundaryBase>>> boundaries_;
 
     bool has_flag_ = false;
 

--- a/include/scrimmage/plugins/controller/UUV6DOFPIDController/UUV6DOFPIDController.h
+++ b/include/scrimmage/plugins/controller/UUV6DOFPIDController/UUV6DOFPIDController.h
@@ -47,8 +47,8 @@ namespace controller {
 class UUV6DOFPIDController : public scrimmage::Controller {
  public:
     UUV6DOFPIDController();
-    virtual void init(std::map<std::string, std::string> &params);
-    virtual bool step(double t, double dt);
+    void init(std::map<std::string, std::string> &params) override;
+    bool step(double t, double dt) override;
 
  protected:
     // Inputs

--- a/include/scrimmage/plugins/interaction/Boundary/BoundaryInfo.h
+++ b/include/scrimmage/plugins/interaction/Boundary/BoundaryInfo.h
@@ -40,8 +40,6 @@
 #include <string>
 #include <vector>
 
-namespace sc = scrimmage;
-
 namespace scrimmage {
 namespace interaction {
 

--- a/include/scrimmage/plugins/interaction/GRPCCommandString/GRPCCommandString.h
+++ b/include/scrimmage/plugins/interaction/GRPCCommandString/GRPCCommandString.h
@@ -33,13 +33,7 @@
 #ifndef INCLUDE_SCRIMMAGE_PLUGINS_INTERACTION_GRPCCOMMANDSTRING_GRPCCOMMANDSTRING_H_
 #define INCLUDE_SCRIMMAGE_PLUGINS_INTERACTION_GRPCCOMMANDSTRING_GRPCCOMMANDSTRING_H_
 
-#include <grpc++/grpc++.h>
-using grpc::Channel;
-using grpc::ClientContext;
-using grpc::Status;
-
 #include <scrimmage/simcontrol/EntityInteraction.h>
-#include <scrimmage/entity/Entity.h>
 
 #include <scrimmage/msgs/Command.pb.h>
 
@@ -59,9 +53,9 @@ class GRPCCommandString : public scrimmage::EntityInteraction {
  public:
     GRPCCommandString();
     bool init(std::map<std::string, std::string> &mission_params,
-              std::map<std::string, std::string> &plugin_params);
+              std::map<std::string, std::string> &plugin_params) override;
     bool step_entity_interaction(std::list<sc::EntityPtr> &ents,
-                                 double t, double dt);
+                                 double t, double dt) override;
     void run_server();
 
     void push_msg(const scrimmage_msgs::CommandString &msg);

--- a/src/parse/ConfigParse.cpp
+++ b/src/parse/ConfigParse.cpp
@@ -63,7 +63,7 @@ void ConfigParse::set_required(std::string node_name) {
 void ConfigParse::recursive_params(rx::xml_node<char> *root,
         std::map<std::string, std::string> &overrides,
         std::map<std::string, std::string> &params,
-        std::string prev) {
+        const std::string &prev) {
     // End condition
     if (root == 0 || root->name() == std::string("")
         || root->name() == std::string(" ")) {

--- a/src/plugins/autonomy/BoundaryDefense/BoundaryDefense.cpp
+++ b/src/plugins/autonomy/BoundaryDefense/BoundaryDefense.cpp
@@ -39,8 +39,10 @@
 #include <scrimmage/pubsub/Publisher.h>
 #include <scrimmage/pubsub/Subscriber.h>
 
+#include <scrimmage/plugins/interaction/Boundary/BoundaryBase.h>
 #include <scrimmage/plugins/interaction/Boundary/Cuboid.h>
 #include <scrimmage/plugins/interaction/Boundary/Sphere.h>
+
 #include <scrimmage/plugins/autonomy/WaypointGenerator/Waypoint.h>
 #include <scrimmage/plugins/autonomy/WaypointGenerator/WaypointList.h>
 
@@ -53,6 +55,7 @@ using std::cout;
 using std::endl;
 
 namespace sc = scrimmage;
+namespace sci = scrimmage::interaction;
 
 REGISTER_PLUGIN(scrimmage::Autonomy,
                 scrimmage::autonomy::BoundaryDefense,

--- a/src/plugins/autonomy/TakeFlag/TakeFlag.cpp
+++ b/src/plugins/autonomy/TakeFlag/TakeFlag.cpp
@@ -42,6 +42,7 @@
 #include <scrimmage/plugins/interaction/Boundary/BoundaryInfo.h>
 #include <scrimmage/plugins/interaction/Boundary/Cuboid.h>
 #include <scrimmage/plugins/interaction/Boundary/Sphere.h>
+#include <scrimmage/plugins/interaction/Boundary/BoundaryBase.h>
 
 #include <scrimmage/plugins/autonomy/WaypointGenerator/Waypoint.h>
 #include <scrimmage/plugins/autonomy/WaypointGenerator/WaypointList.h>
@@ -56,8 +57,8 @@
 using std::cout;
 using std::endl;
 
-namespace sc = scrimmage;
 namespace sm = scrimmage_msgs;
+namespace sci = scrimmage::interaction;
 
 REGISTER_PLUGIN(scrimmage::Autonomy,
                 scrimmage::autonomy::TakeFlag,
@@ -72,8 +73,8 @@ TakeFlag::TakeFlag() {
 void TakeFlag::init(std::map<std::string, std::string> &params) {
     pub_wp_list_ = advertise("LocalNetwork", "WaypointList");
 
-    flag_boundary_id_ = sc::get<int>("flag_boundary_id", params, 1);
-    capture_boundary_id_ = sc::get<int>("capture_boundary_id", params, 1);
+    flag_boundary_id_ = get<int>("flag_boundary_id", params, 1);
+    capture_boundary_id_ = get<int>("capture_boundary_id", params, 1);
 
     auto callback = [&] (scrimmage::MessagePtr<sci::BoundaryInfo> msg) {
         if (msg->data.type == sci::BoundaryInfo::Type::Cuboid) {
@@ -119,7 +120,7 @@ bool TakeFlag::step_autonomy(double t, double dt) {
 }
 
 void TakeFlag::publish_waypoint(const Eigen::Vector3d &point) {
-    auto path_msg = std::make_shared<sc::Message<WaypointList>>();
+    auto path_msg = std::make_shared<Message<WaypointList>>();
     path_msg->data.set_mode(WaypointList::WaypointMode::follow_once);
     path_msg->data.set_cycles(1);
 

--- a/src/plugins/controller/UUV6DOFPIDController/UUV6DOFPIDController.cpp
+++ b/src/plugins/controller/UUV6DOFPIDController/UUV6DOFPIDController.cpp
@@ -45,8 +45,6 @@
 using std::cout;
 using std::endl;
 
-namespace sc = scrimmage;
-
 REGISTER_PLUGIN(scrimmage::Controller,
                 scrimmage::controller::UUV6DOFPIDController,
                 UUV6DOFPIDController_plugin)

--- a/src/plugins/interaction/Boundary/Boundary.cpp
+++ b/src/plugins/interaction/Boundary/Boundary.cpp
@@ -69,11 +69,11 @@ bool Boundary::init(std::map<std::string, std::string> &mission_params,
                                                      plugin_params,
                                                      "cuboid");
 
-    std::vector<std::vector<std::string>> vecs;
     std::string cuboid_boundary = sc::get<std::string>("cuboid_boundary",
                                                        plugin_params, "");
 
     if (boundary_type == "cuboid") {
+        std::vector<std::vector<std::string>> vecs;
         if (!sc::get_vec_of_vecs(cuboid_boundary, vecs)) {
             cout << "Failed to parse cuboid_boundary." << endl;
             return false;

--- a/src/plugins/interaction/GRPCCommandString/GRPCCommandString.cpp
+++ b/src/plugins/interaction/GRPCCommandString/GRPCCommandString.cpp
@@ -29,6 +29,7 @@
  * A Long description goes here.
  *
  */
+#include <grpc++/grpc++.h>
 
 #include <scrimmage/plugins/interaction/GRPCCommandString/GRPCCommandString.h>
 #include <scrimmage/plugins/interaction/GRPCCommandString/ScrimmageMsgServiceImpl.h>

--- a/src/plugins/motion/JSBSimModel/FGOutputFGMod.cpp
+++ b/src/plugins/motion/JSBSimModel/FGOutputFGMod.cpp
@@ -35,6 +35,8 @@
 #include <stdio.h>
 #include <string.h>
 
+#include <algorithm>
+
 #include "models/FGAerodynamics.h"
 #include "models/FGAuxiliary.h"
 #include "models/FGPropulsion.h"
@@ -44,10 +46,6 @@
 #include "models/FGFCS.h"
 #include "models/propulsion/FGPiston.h"
 #include "models/propulsion/FGTank.h"
-
-#if !defined (min)
-#  define min(X, Y) X < Y ? X : Y
-#endif
 
 // NOTE: This file has a couple of quirky ways of converting between data types
 // because it's how it is done in FlightGear / JSBSim. That's why there are
@@ -156,7 +154,8 @@ void FGOutputFGMod::SocketDataFillMod(FGNetFDM* net) {
          << "version of FlightGear's FGNetFDM only supports " << FGNetFDM::FG_MAX_ENGINES << " engines." << endl
          << "Only the first " << FGNetFDM::FG_MAX_ENGINES << " engines will be used." << endl;
 
-  net->num_engines = min(FGNetFDM::FG_MAX_ENGINES, Propulsion->GetNumEngines()); // Number of valid engines
+  net->num_engines = std::min(static_cast<unsigned int>(FGNetFDM::FG_MAX_ENGINES),
+                              Propulsion->GetNumEngines()); // Number of valid engines
 
   for (i=0; i < net->num_engines; i++) {
     if (Propulsion->GetEngine(i)->GetRunning())
@@ -197,7 +196,8 @@ void FGOutputFGMod::SocketDataFillMod(FGNetFDM* net) {
          << "version of FlightGear's FGNetFDM only supports " << FGNetFDM::FG_MAX_TANKS << " tanks." << endl
          << "Only the first " << FGNetFDM::FG_MAX_TANKS << " tanks will be used." << endl;
 
-  net->num_tanks = min(FGNetFDM::FG_MAX_TANKS, Propulsion->GetNumTanks());   // Max number of fuel tanks
+  net->num_tanks = std::min(static_cast<unsigned int>(FGNetFDM::FG_MAX_TANKS),
+                            Propulsion->GetNumTanks());   // Max number of fuel tanks
 
   for (i=0; i < net->num_tanks; i++) {
       net->fuel_quantity[i] = static_cast<float>((static_cast<FGTank *>(Propulsion->GetTank(i))->GetContents()));
@@ -209,7 +209,8 @@ void FGOutputFGMod::SocketDataFillMod(FGNetFDM* net) {
          << "version of FlightGear's FGNetFDM only supports " << FGNetFDM::FG_MAX_WHEELS << " bogeys." << endl
          << "Only the first " << FGNetFDM::FG_MAX_WHEELS << " bogeys will be used." << endl;
 
-  net->num_wheels  = min(FGNetFDM::FG_MAX_WHEELS, GroundReactions->GetNumGearUnits());
+  net->num_wheels  = std::min(static_cast<int>(FGNetFDM::FG_MAX_WHEELS),
+                              GroundReactions->GetNumGearUnits());
 
   for (i=0; i < net->num_wheels; i++) {
     net->wow[i]              = GroundReactions->GetGearUnit(i)->GetWOW();

--- a/tools/aggregate-runs/main.cpp
+++ b/tools/aggregate-runs/main.cpp
@@ -80,12 +80,12 @@ int main(int argc, char *argv[]) {
     // Find all summary.csv files under the directory
     std::vector<std::string> paths;
     fs::path root = log_dir;
-    std::string summary_csv = "summary.csv";
     if (fs::exists(root) && fs::is_directory(root)) {
         fs::recursive_directory_iterator it(root);
         fs::recursive_directory_iterator endit;
 
         while (it != endit) {
+            const std::string summary_csv = "summary.csv";
             if (fs::is_regular_file(*it) && it->path().filename() == summary_csv) {
                 std::string full_path = fs::absolute(it->path()).string();
                 paths.push_back(full_path);

--- a/tools/filter-runs/main.cpp
+++ b/tools/filter-runs/main.cpp
@@ -64,12 +64,12 @@ int main(int argc, char *argv[]) {
     // Find all .txt files under the directory
     std::vector<std::string> paths;
     fs::path root = dir;
-    std::string ext = ".result";
     if (fs::exists(root) && fs::is_directory(root)) {
         fs::recursive_directory_iterator it(root);
         fs::recursive_directory_iterator endit;
 
         while (it != endit) {
+            const std::string ext = ".result";
             if (fs::is_regular_file(*it) && it->path().extension() == ext) {
                 std::string full_path = fs::absolute(it->path()).string();
                 paths.push_back(full_path);

--- a/tools/scrimmage-plugin/main.cpp
+++ b/tools/scrimmage-plugin/main.cpp
@@ -68,7 +68,6 @@ int main(int argc, char *argv[]) {
         return 1;
     }
 
-    std::string plugin_type = "autonomy";
     std::map<std::string, std::string> overrides;
     std::string plugin_name_xml;
     if (vm.count("plugin-name")) {
@@ -83,6 +82,7 @@ int main(int argc, char *argv[]) {
     sc::ConfigParse config_parse;
     config_parse.set_required("library");
     if (!config_parse.parse(overrides, plugin_name_xml, "SCRIMMAGE_PLUGIN_PATH", file_search, verbose)) {
+        const std::string plugin_type = "autonomy";
         std::cout << "Failed to parse: " << plugin_name_xml << " for type " << plugin_type << std::endl;
         return -2;
     }


### PR DESCRIPTION
* remove "namespace sc = sci" in headers
* use forward declarations
* put variables in reduced scope
* use const references for object passing
* use override instead of virtual
* remove use of macro for min