### PR TITLE
add eigen include dirs to install tree

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -67,7 +67,7 @@ set_target_properties(
 
 target_include_directories(${LIBRARY_NAME}
   PUBLIC
-    $<INSTALL_INTERFACE:include>
+    "$<INSTALL_INTERFACE:include;${EIGEN3_INCLUDE_DIR};${GeographicLib_INCLUDE_DIRS}>"
     "$<BUILD_INTERFACE:${SCRIMMAGE_INC_DIR};${EIGEN3_INCLUDE_DIR};${GeographicLib_INCLUDE_DIRS}>"
 )
 


### PR DESCRIPTION
Added Eigen include dirs as interface include directories for
scrimmage-core in the install tree. This will fix potential
\#include errors for Eigen when scrimmage has been installed
to a nonstandard location.