### PR TITLE
Fixed missing proto includes in install tree

### DIFF
--- a/msgs/CMakeLists.txt
+++ b/msgs/CMakeLists.txt
@@ -101,7 +101,7 @@ set_target_properties(
 
 target_include_directories(${LIBRARY_NAME}
   PUBLIC
-    $<INSTALL_INTERFACE:include>
+    "$<INSTALL_INTERFACE:include;${PROTOBUF_INCLUDE_DIRS}>"
     "$<BUILD_INTERFACE:${MSGS_INCLUDE_DIR};${PROTOBUF_INCLUDE_DIRS}>"
 )
 

--- a/src/proto/CMakeLists.txt
+++ b/src/proto/CMakeLists.txt
@@ -132,7 +132,7 @@ set_target_properties(
 
 target_include_directories(${LIBRARY_NAME}
   PUBLIC
-    $<INSTALL_INTERFACE:include>
+    "$<INSTALL_INTERFACE:include;${PROTOBUF_INCLUDE_DIRS}>"
     "$<BUILD_INTERFACE:${PROTO_INCLUDE_DIR};${PROTOBUF_INCLUDE_DIRS}>"
 )
 


### PR DESCRIPTION
Should be ready to go, just protobuf headers missing from install tree.

@crichardson332