### PR TITLE
Fix sensor shapes not disappearing

### DIFF
--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -1197,6 +1197,7 @@ bool SimControl::run_sensors() {
                 return false;
             }
             shapes.insert(shapes.end(), sensor->shapes().begin(), sensor->shapes().end());
+            sensor->shapes().clear();
         }
     }
     return true;


### PR DESCRIPTION
Sensor drawn shapes weren't disappearing in the viewer after draw_shape() even with persistent set to false and a small TTL set.

Introduced by https://github.com/gtri/scrimmage/commit/b294986148b42cc6d79c5e8e84702c41de229870 which allowed sensors to display shapes in the viewer.