### PR TITLE
Allow External to step through sensor plugins

### DIFF
--- a/src/entity/External.cpp
+++ b/src/entity/External.cpp
@@ -207,6 +207,11 @@ bool External::step(double t) {
         autonomy->step_autonomy(t, dt);
     }
 
+    for (const auto &kv : entity_->sensors()) {
+        SensorPtr sensor = kv.second;
+        sensor->step();
+    }
+
     entity_->setup_desired_state();
 
     int num_steps = dt <= min_motion_dt ? 1 : ceil(dt / min_motion_dt);


### PR DESCRIPTION
Added code to call the step function of sensor plugins when using the external class.