### PR TITLE
Added planar boundary in SphereNetwork.

### DIFF
--- a/include/scrimmage/plugins/network/SphereNetwork/SphereNetwork.h
+++ b/include/scrimmage/plugins/network/SphereNetwork/SphereNetwork.h
@@ -61,7 +61,7 @@ class SphereNetwork : public scrimmage::Network {
     // The buffer zone around the boundary plane that doesn't directly block
     // comms
     double comms_boundary_epsilon_;
-    bool filter_comms_plane_;
+    bool filter_comms_plane_ = false;
     bool within_planar_boundary(double z1, double z2);
 };
 } // namespace network

--- a/include/scrimmage/plugins/network/SphereNetwork/SphereNetwork.h
+++ b/include/scrimmage/plugins/network/SphereNetwork/SphereNetwork.h
@@ -53,6 +53,16 @@ class SphereNetwork : public scrimmage::Network {
                                             const scrimmage::PluginPtr &sub_plugin) override;
     double range_;
     double prob_transmit_;
+
+    // Attributes of a boundary plane that blocks communication. Example use
+    // would be putting a boundary at a water/air intersection such that
+    // communications wouldn't go between water and the surface.
+    double comms_boundary_altitude_;
+    // The buffer zone around the boundary plane that doesn't directly block
+    // comms
+    double comms_boundary_epsilon_;
+    bool filter_comms_plane_;
+    bool within_planar_boundary(double z1, double z2);
 };
 } // namespace network
 } // namespace scrimmage

--- a/include/scrimmage/plugins/network/SphereNetwork/SphereNetwork.h
+++ b/include/scrimmage/plugins/network/SphereNetwork/SphereNetwork.h
@@ -57,10 +57,10 @@ class SphereNetwork : public scrimmage::Network {
     // Attributes of a boundary plane that blocks communication. Example use
     // would be putting a boundary at a water/air intersection such that
     // communications wouldn't go between water and the surface.
-    double comms_boundary_altitude_;
+    double comms_boundary_altitude_ = 0;
     // The buffer zone around the boundary plane that doesn't directly block
     // comms
-    double comms_boundary_epsilon_;
+    double comms_boundary_epsilon_ = 0;
     bool filter_comms_plane_ = false;
     bool within_planar_boundary(double z1, double z2);
 };

--- a/include/scrimmage/plugins/network/SphereNetwork/SphereNetwork.xml
+++ b/include/scrimmage/plugins/network/SphereNetwork/SphereNetwork.xml
@@ -4,6 +4,9 @@
   <library>SphereNetwork_plugin</library>
   <range>100</range>
   <prob_transmit>1.0</prob_transmit>
+  <filter_comms_plane>0</filter_comms_plane>
+  <comms_boundary_altitude>0</comms_boundary_altitude>
+  <comms_boundary_epsilon>0</comms_boundary_epsilon>
 
   <monitor_publisher_topics/>
   <monitor_subscriber_topics/>

--- a/include/scrimmage/plugins/network/SphereNetwork/SphereNetwork.xml
+++ b/include/scrimmage/plugins/network/SphereNetwork/SphereNetwork.xml
@@ -4,10 +4,9 @@
   <library>SphereNetwork_plugin</library>
   <range>100</range>
   <prob_transmit>1.0</prob_transmit>
-  <filter_comms_plane>0</filter_comms_plane>
-  <comms_boundary_altitude>0</comms_boundary_altitude>
-  <comms_boundary_epsilon>0</comms_boundary_epsilon>
-
+  <filter_comms_plane>false</filter_comms_plane>
+  <comms_boundary_altitude/>
+  <comms_boundary_epsilon/>
   <monitor_publisher_topics/>
   <monitor_subscriber_topics/>
   <csv_filename/>

--- a/src/plugins/network/SphereNetwork/SphereNetwork.cpp
+++ b/src/plugins/network/SphereNetwork/SphereNetwork.cpp
@@ -70,11 +70,10 @@ bool SphereNetwork::init(std::map<std::string, std::string> &mission_params,
             filter_comms_plane_);
     if (filter_comms_plane_) {
         comms_boundary_altitude_ = sc::get<double>("comms_boundary_altitude",
-                plugin_params, std::numeric_limits<double>::quiet_NaN());
+                plugin_params, comms_boundary_altitude_);
         comms_boundary_epsilon_ = sc::get<double>("comms_boundary_epsilon",
-                plugin_params, std::numeric_limits<double>::quiet_NaN());
-        comms_boundary_epsilon_ =
-            std::stod(plugin_params.at("comms_boundary_epsilon")); }
+                plugin_params, comms_boundary_epsilon_);
+    }
     return true;
 }
 

--- a/src/plugins/network/SphereNetwork/SphereNetwork.cpp
+++ b/src/plugins/network/SphereNetwork/SphereNetwork.cpp
@@ -41,6 +41,7 @@
 #include <scrimmage/pubsub/Publisher.h>
 #include <scrimmage/pubsub/Subscriber.h>
 #include <scrimmage/pubsub/Message.h>
+#include <scrimmage/parse/ParseUtils.h>
 
 #include <iostream>
 #include <vector>
@@ -65,9 +66,15 @@ bool SphereNetwork::init(std::map<std::string, std::string> &mission_params,
 
     range_ = std::stod(plugin_params.at("range"));
     prob_transmit_ = std::stod(plugin_params.at("prob_transmit"));
-    filter_comms_plane_ = std::stoi(plugin_params.at("filter_comms_plane"));
-    comms_boundary_altitude_ = std::stod(plugin_params.at("comms_boundary_altitude"));
-    comms_boundary_epsilon_ = std::stod(plugin_params.at("comms_boundary_epsilon"));
+    filter_comms_plane_ = sc::get<bool>("filter_comms_plane", plugin_params,
+            filter_comms_plane_);
+    if (filter_comms_plane_) {
+        comms_boundary_altitude_ = sc::get<double>("comms_boundary_altitude",
+                plugin_params, std::numeric_limits<double>::quiet_NaN());
+        comms_boundary_epsilon_ = sc::get<double>("comms_boundary_epsilon",
+                plugin_params, std::numeric_limits<double>::quiet_NaN());
+        comms_boundary_epsilon_ =
+            std::stod(plugin_params.at("comms_boundary_epsilon")); }
     return true;
 }
 

--- a/src/plugins/network/SphereNetwork/SphereNetwork.cpp
+++ b/src/plugins/network/SphereNetwork/SphereNetwork.cpp
@@ -133,7 +133,6 @@ bool SphereNetwork::within_planar_boundary(double z1, double z2) {
     bool both_below = (z1 <= (comms_boundary_altitude_ + comms_boundary_epsilon_))
         && (z2 <= (comms_boundary_altitude_ + comms_boundary_epsilon_));
     return (both_above || both_below);
-
 }
 
 } // namespace network

--- a/src/simcontrol/SimUtils.cpp
+++ b/src/simcontrol/SimUtils.cpp
@@ -390,6 +390,8 @@ bool create_networks(const SimUtilsInfo &info, NetworkMap &networks) {
         network->set_pubsub(info.pubsub);
         network->set_random(info.random);
         network->set_rtree(info.rtree);
+        network->set_id_to_team_map(info.id_to_team_map);
+        network->set_id_to_ent_map(info.id_to_ent_map);
 
         if (network == nullptr) {
             std::cout << "Failed to load network plugin: "


### PR DESCRIPTION
There is now an option to add a planar boundary to the sphere network.
A use case example is to model underwater communications not being able
to go beyond the surface of the water to aerial vehicles and vice versa.