### PR TITLE
Override parameters from external, plugin tags for external

### DIFF
--- a/include/scrimmage/common/Utilities.h
+++ b/include/scrimmage/common/Utilities.h
@@ -39,7 +39,14 @@
 #include <vector>
 #include <string>
 
+#include <memory>
+#include <array>
+#include <stdexcept>
+#include <cstdio>
+
 namespace scrimmage {
+
+std::string exec_command(const char* cmd);
 
 void display_progress(float progress);
 

--- a/include/scrimmage/common/Utilities.h
+++ b/include/scrimmage/common/Utilities.h
@@ -39,14 +39,7 @@
 #include <vector>
 #include <string>
 
-#include <memory>
-#include <array>
-#include <stdexcept>
-#include <cstdio>
-
 namespace scrimmage {
-
-std::string exec_command(const char* cmd);
 
 void display_progress(float progress);
 

--- a/include/scrimmage/entity/Entity.h
+++ b/include/scrimmage/entity/Entity.h
@@ -40,6 +40,7 @@
 #include <scrimmage/pubsub/Message.h>
 
 #include <map>
+#include <set>
 #include <unordered_map>
 #include <list>
 #include <vector>
@@ -73,7 +74,12 @@ class Entity : public std::enable_shared_from_this<Entity> {
               FileSearchPtr &file_search,
               RTreePtr &rtree,
               PubSubPtr &pubsub,
-              TimePtr &time);
+              TimePtr &time,
+              const std::set<std::string> &plugin_tags,
+              std::function<void(std::map<std::string, std::string>&)> param_override_func
+        );
+
+    void print_plugins(std::ostream &out) const;
 
     bool parse_visual(std::map<std::string, std::string> &info,
                       MissionParsePtr mp,
@@ -174,12 +180,6 @@ class Entity : public std::enable_shared_from_this<Entity> {
     }
 
     double radius() { return radius_; }
-
-    ControllerPtr init_controller(
-        const std::string &name,
-        std::map<std::string, std::string> &overrides,
-        VariableIO &next_io);
-
     void set_time_ptr(TimePtr t);
     ///@}
 

--- a/include/scrimmage/entity/External.h
+++ b/include/scrimmage/entity/External.h
@@ -66,7 +66,7 @@ class External {
     External();
     EntityPtr &entity();
     bool create_entity(const std::string &mission_file,
-                       const std::string &entity_name,
+                       const std::string &entity_tag,
                        const std::string &plugin_tags_str,
                        int entity_id,
                        int max_entities,

--- a/include/scrimmage/entity/External.h
+++ b/include/scrimmage/entity/External.h
@@ -49,6 +49,7 @@
 #include <functional>
 #include <list>
 #include <map>
+#include <set>
 #include <string>
 #include <mutex> // NOLINT
 
@@ -64,40 +65,30 @@ class External {
  public:
     External();
     EntityPtr &entity();
-    void setup_logging();
-    bool create_entity(int max_entities, int entity_id,
+    bool create_entity(const std::string &mission_file,
                        const std::string &entity_name,
-                       bool connect_entity = true);
-
-    template <class AcceptFunc>
-    bool create_entity(int max_entities, int entity_id,
-                       const std::string &entity_name,
-                       AcceptFunc accept_func, bool connect_entity = true) {
-
-        if (!create_entity(max_entities, entity_id, entity_name, connect_entity)) {
-            return false;
-        }
-
-        auto filter_func = [&](auto &p) {return !accept_func(p);};
-        auto &a = entity_->autonomies();
-        a.erase(std::remove_if(a.begin(), a.end(), filter_func), a.end());
-
-        return true;
-    }
-
+                       const std::string &plugin_tags_str,
+                       int entity_id,
+                       int max_entities,
+                       const std::string &log_dir,
+                       std::function<void(std::map<std::string, std::string>&)> param_override_func = [](std::map<std::string, std::string>&){});
     void close();
     bool create_interactions();
 
-    double min_motion_dt = 1;
+    double motion_dt_ = 1;
     VariableIO vars;
     std::mutex mutex;
     DelayedTask update_contacts_task;
     MissionParsePtr mp();
     bool send_messages();
 
+    void print_plugins(std::ostream &out) const;
+
  protected:
+    void setup_logging(const std::string &log_dir);
     void update_ents();
     EntityPtr entity_;
+    bool enable_motion_ = false;
     std::list<EntityInteractionPtr> ent_inters_;
     std::list<MetricsPtr> metrics_;
     NetworkMapPtr networks_;

--- a/include/scrimmage/parse/MissionParse.h
+++ b/include/scrimmage/parse/MissionParse.h
@@ -108,7 +108,7 @@ class MissionParse {
 
     EntityDesc_t & entity_descriptions();
 
-    std::map<std::string, int> & entity_name_to_id();
+    std::map<std::string, int> & entity_tag_to_id();
 
     bool enable_gui();
     void set_enable_gui(bool enable);
@@ -195,7 +195,7 @@ class MissionParse {
     // Key: entity_description ID in EntityDesc_t vector
     std::map<int, std::vector<double> > next_gen_times_;
 
-    std::map<std::string, int> entity_name_to_id_;
+    std::map<std::string, int> entity_tag_to_id_;
 
     std::shared_ptr<GeographicLib::LocalCartesian> proj_;
 

--- a/include/scrimmage/parse/ParseUtils.h
+++ b/include/scrimmage/parse/ParseUtils.h
@@ -86,20 +86,34 @@ void split(std::vector<std::string> &tokens, const std::string &str,
            const std::string &delims);
 
 template <typename T>
-std::set<T> str2set(const std::string &str, const std::string &delims) {
-    std::set<T> out;
+T str2container(const std::string &str, const std::string &delims) {
+    T out;
     std::vector<std::string> tokens;
     split(tokens, str, delims);
 
     for (std::string &t : tokens) {
         if (t.length() > 0) {
-            out.emplace(convert<T>(t));
+            out.insert(out.end(), convert<typename T::value_type>(t));
         }
     }
     return out;
 }
 
 template <typename T>
+bool str2container(const std::string &str, const std::string &delims,
+                   T &result, int size = -1) {
+    T tmp = str2container<T>(str, delims);
+    if (size >= 0 && (unsigned int)size != tmp.size()) {
+        return false;
+    } else {
+        // Only modify vec if it was a valid conversion
+        result = tmp;
+        return true;
+    }
+}
+
+template <typename T>
+[[deprecated("str2vec is deprecated, use str2container instead")]]
 std::vector<T> str2vec(const std::string &str, const std::string &delims) {
     std::vector<T> out;
     std::vector<std::string> tokens;
@@ -114,6 +128,7 @@ std::vector<T> str2vec(const std::string &str, const std::string &delims) {
 }
 
 template <typename T>
+[[deprecated("str2vec is deprecated, use str2container instead")]]
 bool str2vec(const std::string &str, const std::string &delims,
              std::vector<T> &vec, int size = -1) {
     std::vector<T> tmp_vec;
@@ -142,7 +157,7 @@ bool get_vec(const std::string &str,
              std::vector<T> &vec,
              int size = -1) {
     auto it = params.find(str);
-    return it == params.end() ? false : str2vec<T>(it->second, delims, vec, size);
+    return it == params.end() ? false : str2container(it->second, delims, vec, size);
 }
 
 bool get_vec(const std::string &str,

--- a/include/scrimmage/parse/ParseUtils.h
+++ b/include/scrimmage/parse/ParseUtils.h
@@ -35,6 +35,7 @@
 #include <Eigen/Dense>
 
 #include <map>
+#include <set>
 #include <vector>
 #include <string>
 #include <memory>
@@ -83,6 +84,20 @@ template <class T1, class T2 = T1>
 // a wrapper around boost so that boost does not have to be included
 void split(std::vector<std::string> &tokens, const std::string &str,
            const std::string &delims);
+
+template <typename T>
+std::set<T> str2set(const std::string &str, const std::string &delims) {
+    std::set<T> out;
+    std::vector<std::string> tokens;
+    split(tokens, str, delims);
+
+    for (std::string &t : tokens) {
+        if (t.length() > 0) {
+            out.emplace(convert<T>(t));
+        }
+    }
+    return out;
+}
 
 template <typename T>
 std::vector<T> str2vec(const std::string &str, const std::string &delims) {

--- a/include/scrimmage/plugin_manager/PluginManager.h
+++ b/include/scrimmage/plugin_manager/PluginManager.h
@@ -116,14 +116,15 @@ class PluginManager {
             bool valid_tag = false;
             auto it_tags = overrides.find("tags");
             if (it_tags != overrides.end()) {
-                // Do any of the plugin tags match the tags for this plugin?
-                std::set<std::string> tags = str2set<std::string>(it_tags->second, ", ");
-                for (const std::string &tag: tags) {
-                    if (plugin_tags.find(tag) != plugin_tags.end()) {
-                        valid_tag = true;
-                        break;
-                    }
-                }
+                // Break up the plugin's tags attribute into a set of strings
+                auto tags = str2container<std::set<std::string>>(it_tags->second, ", ");
+                // If the plugin_tags contains any tag in tags, this plugin
+                // should be loaded
+                valid_tag = std::any_of(tags.begin(), tags.end(),
+                                        [&](const std::string &tag) {
+                                            return (plugin_tags.find(tag) !=
+                                                    plugin_tags.end());
+                                        });
             }
             if (not valid_tag) {
                 status.status = PluginStatus<T>::invalid_tag;

--- a/include/scrimmage/plugin_manager/PluginManager.h
+++ b/include/scrimmage/plugin_manager/PluginManager.h
@@ -34,12 +34,23 @@
 #define INCLUDE_SCRIMMAGE_PLUGIN_MANAGER_PLUGINMANAGER_H_
 
 #include <scrimmage/fwd_decl.h>
+#include <scrimmage/parse/ConfigParse.h>
+#include <scrimmage/parse/ParseUtils.h>
+#include <scrimmage/common/FileSearch.h>
 
+#include <iostream>
 #include <list>
 #include <map>
+#include <set>
 #include <unordered_set>
 #include <memory>
 #include <string>
+
+#ifdef __APPLE__
+#define LIB_EXT ".dylib"
+#else
+#define LIB_EXT ".so"
+#endif
 
 namespace scrimmage {
 
@@ -55,6 +66,14 @@ class PluginInfo {
     void * handle = nullptr;
 };
 
+template <class T>
+class PluginStatus {
+ public:
+    enum Status {parse_failed, invalid_tag, missing, loaded, cast_failed};
+    Status status = missing;
+    std::shared_ptr<T> plugin = nullptr;
+};
+
 class PluginManager {
  public:
     typedef const char * (*plugin_name_t)();
@@ -66,12 +85,118 @@ class PluginManager {
                        const std::string &title,
                        FileSearch &file_search);
     void print_returned_plugins();
-    PluginPtr make_plugin(
-        std::string plugin_type,
-        const std::string &plugin_name_xml,
-        FileSearch &file_search,
-        ConfigParse &config_parse,
-        std::map<std::string, std::string> &overrides);
+
+    template <class T>
+    PluginStatus<T> make_plugin(std::string plugin_type,
+                                const std::string &plugin_name_xml,
+                                FileSearch &file_search,
+                                ConfigParse &config_parse,
+                                std::map<std::string, std::string> &overrides,
+                                const std::set<std::string> &plugin_tags) {
+        PluginStatus<T> status;
+        std::string plugin_name = plugin_name_xml;
+        auto it_orig_plugin_name = overrides.find("ORIGINAL_PLUGIN_NAME");
+        if (it_orig_plugin_name != overrides.end()) {
+            plugin_name = it_orig_plugin_name->second;
+        }
+
+        config_parse.set_required("library");
+        if (!config_parse.parse(overrides, plugin_name, "SCRIMMAGE_PLUGIN_PATH", file_search)) {
+            std::cout << "Failed to parse: " << plugin_name << ".xml for type " << plugin_type << std::endl;
+            std::cout << "Check that you have sourced ~/.scrimmage/setup.bash "
+                      << "(this sets the environment variable SCRIMMAGE_PLUGIN_PATH to a directory including "
+                      << plugin_name << ".xml)" << std::endl;
+            status.status = PluginStatus<T>::parse_failed;
+            return status;
+        }
+
+        // If the plugin_tags aren't empty, then we filter based on plugin_tags
+        if (not plugin_tags.empty()) {
+            // Does this plugin have a plugin "tags" attribute
+            bool valid_tag = false;
+            auto it_tags = overrides.find("tags");
+            if (it_tags != overrides.end()) {
+                // Do any of the plugin tags match the tags for this plugin?
+                std::set<std::string> tags = str2set<std::string>(it_tags->second, ", ");
+                for (const std::string &tag: tags) {
+                    if (plugin_tags.find(tag) != plugin_tags.end()) {
+                        valid_tag = true;
+                        break;
+                    }
+                }
+            }
+            if (not valid_tag) {
+                status.status = PluginStatus<T>::invalid_tag;
+                return status;
+            }
+        }
+
+        std::string plugin_name_so = config_parse.params()["library"];
+
+        // first, if this has already been processed, return it
+        PluginPtr plugin = make_plugin_helper(plugin_type, plugin_name_so);
+        if (plugin != nullptr) {
+            status.plugin = std::dynamic_pointer_cast<T>(plugin);
+            if (status.plugin == nullptr) {
+                status.status = PluginStatus<T>::cast_failed;
+            } else {
+                status.status = PluginStatus<T>::loaded;
+            }
+            return status;
+        }
+
+        if (!files_checked_ && so_files_.empty()) {
+            file_search.find_files("SCRIMMAGE_PLUGIN_PATH", LIB_EXT, so_files_);
+            files_checked_ = true;
+        }
+
+        // try the most obvious case, that the lib is named the same as the
+        // plugin_name
+        auto it = so_files_.find(std::string("lib") + plugin_name_so + LIB_EXT);
+        if (it != so_files_.end()) {
+            for (std::string &full_fname : it->second) {
+                if (check_library(full_fname) == 0) {
+                    // don't need to check again that it is in the map since the helper
+                    // will do this already
+                    so_files_.erase(it);
+                    PluginPtr plugin = make_plugin_helper(plugin_type, plugin_name_so);
+                    status.plugin = std::dynamic_pointer_cast<T>(plugin);
+                    if (status.plugin == nullptr) {
+                        status.status = PluginStatus<T>::cast_failed;
+                    } else {
+                        status.status = PluginStatus<T>::loaded;
+                    }
+                    return status;
+                }
+            }
+        }
+
+        // last, loop through the files
+        it = so_files_.begin();
+        while (it != so_files_.end()) {
+            for (std::string &full_fname : it->second) {
+                if (check_library(full_fname) == 0) {
+                    // don't need to check again that it is in the map since the helper
+                    // will do this already
+                    so_files_.erase(it);
+                    PluginPtr plugin = make_plugin_helper(plugin_type, plugin_name_so);
+                    status.plugin = std::dynamic_pointer_cast<T>(plugin);
+                    if (status.plugin == nullptr) {
+                        status.status = PluginStatus<T>::cast_failed;
+                    } else {
+                        status.status = PluginStatus<T>::loaded;
+                    }
+                    return status;
+                }
+            }
+            it++;
+        }
+
+        std::cout << "could not locate " << plugin_type << "::" << plugin_name_so << std::endl;
+        status.status = PluginStatus<T>::missing;
+        return status;
+    }
+
     std::map<std::string, std::unordered_set<std::string>> get_commits();
     void set_reload(bool reload);
     bool get_reload();

--- a/include/scrimmage/simcontrol/SimUtils.h
+++ b/include/scrimmage/simcontrol/SimUtils.h
@@ -66,17 +66,20 @@ bool create_ent_inters(const SimUtilsInfo &info,
                        ContactMapPtr contacts,
                        std::list<scrimmage_proto::ShapePtr> &shapes,
                        std::list<EntityInteractionPtr> &ent_inters,
-                       const std::set<std::string> &plugin_tags,
-                       std::function<void(std::map<std::string, std::string>&)> param_override_func);
+                       const std::set<std::string> &plugin_tags = {},
+                       std::function<void(std::map<std::string, std::string>&)>
+                       param_override_func = [](std::map<std::string, std::string>&){});
 
 bool create_metrics(const SimUtilsInfo &info, ContactMapPtr contacts,
                     std::list<MetricsPtr> &metrics_list,
-                    const std::set<std::string> &plugin_tags,
-                    std::function<void(std::map<std::string, std::string>&)> param_override_func);
+                    const std::set<std::string> &plugin_tags = {},
+                    std::function<void(std::map<std::string, std::string>&)>
+                    param_override_func = [](std::map<std::string, std::string>&){});
 
 bool create_networks(const SimUtilsInfo &info, NetworkMap &networks,
-                     const std::set<std::string> &plugin_tags,
-                     std::function<void(std::map<std::string, std::string>&)> param_override_func);
+                     const std::set<std::string> &plugin_tags = {},
+                     std::function<void(std::map<std::string, std::string>&)>
+                     param_override_func = [](std::map<std::string, std::string>&){});
 
 void run_callbacks(PluginPtr plugin);
 

--- a/include/scrimmage/simcontrol/SimUtils.h
+++ b/include/scrimmage/simcontrol/SimUtils.h
@@ -40,6 +40,8 @@
 #include <memory>
 #include <unordered_map>
 #include <list>
+#include <set>
+#include <map>
 #include <string>
 
 namespace boost {
@@ -63,12 +65,18 @@ struct SimUtilsInfo {
 bool create_ent_inters(const SimUtilsInfo &info,
                        ContactMapPtr contacts,
                        std::list<scrimmage_proto::ShapePtr> &shapes,
-                       std::list<EntityInteractionPtr> &ent_inters);
+                       std::list<EntityInteractionPtr> &ent_inters,
+                       const std::set<std::string> &plugin_tags,
+                       std::function<void(std::map<std::string, std::string>&)> param_override_func);
 
 bool create_metrics(const SimUtilsInfo &info, ContactMapPtr contacts,
-                    std::list<MetricsPtr> &metrics_list);
+                    std::list<MetricsPtr> &metrics_list,
+                    const std::set<std::string> &plugin_tags,
+                    std::function<void(std::map<std::string, std::string>&)> param_override_func);
 
-bool create_networks(const SimUtilsInfo &info, NetworkMap &networks);
+bool create_networks(const SimUtilsInfo &info, NetworkMap &networks,
+                     const std::set<std::string> &plugin_tags,
+                     std::function<void(std::map<std::string, std::string>&)> param_override_func);
 
 void run_callbacks(PluginPtr plugin);
 

--- a/missions/auction_assign.xml
+++ b/missions/auction_assign.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
-<runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"           
+<runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     name="Multiple Aircraft Takeoff">
-  
-  <run start="0.0" end="10" dt="0.1" 
-       time_warp="10" 
-       enable_gui="true" 
+
+  <run start="0.0" end="10" dt="0.1"
+       time_warp="10"
+       enable_gui="true"
        start_paused="true"/>
-  
-  <end_condition>time</end_condition> <!-- time, one_team, none-->  
-  
+
+  <end_condition>time</end_condition> <!-- time, one_team, none-->
+
   <display_progress>true</display_progress>
-  <terrain>mcmillan</terrain>  
+  <terrain>mcmillan</terrain>
   <background_color>191 191 191</background_color> <!-- Red Green Blue -->
   <gui_update_period>10</gui_update_period> <!-- milliseconds -->
-  
+
   <plot_tracks>false</plot_tracks>
   <run_metrics weights="sasc">true</run_metrics>
   <show_plugins>false</show_plugins>
-  
-  <log_dir>~/.scrimmage/logs</log_dir>  
-      
+
+  <log_dir>~/.scrimmage/logs</log_dir>
+
   <latitude_origin>35.721025</latitude_origin>
   <longitude_origin>-120.767925</longitude_origin>
   <altitude_origin>300</altitude_origin>
   <show_origin>false</show_origin>
-  
-  <network tags="SIL">GlobalNetwork</network>
-  <network tags="SIL" name="CommsNetwork">SphereNetwork</network>
-  
+
+  <network tags="REAL, SIL">GlobalNetwork</network>
+  <network tags="REAL, SIL" name="CommsNetwork">SphereNetwork</network>
+
   <entity_interaction>SimpleCollision</entity_interaction>
-  
+
   <!-- uncomment "seed" and use integer for deterministic results -->
   <seed>0</seed>
-  
+
   <!-- ========================== TEAM 1 ========================= -->
   <entity_common name="auction">
-    <team_id>1</team_id> 
+    <team_id>1</team_id>
     <color>0 0 255</color>
     <count>1</count>
     <health>1</health>
@@ -46,18 +46,18 @@
     <x>0</x>
     <y>0</y>
     <z>100</z>
-    <heading>0</heading>          
+    <heading>0</heading>
     <visual_model>sea-angler</visual_model>
     <controller>SingleIntegratorControllerSimple</controller>
     <motion_model>SingleIntegrator</motion_model>
-  </entity_common> 
+  </entity_common>
 
   <entity entity_common="auction" tag="entity_1">
-    <autonomy tags="REAL, SIL" auctioneer="true">AuctionAssign</autonomy>            
+    <autonomy tags="REAL, SIL" auctioneer="true">AuctionAssign</autonomy>
   </entity>
 
   <entity entity_common="auction" tag="entity_2">
-    <autonomy tags="REAL, SIL" auctioneer="false">AuctionAssign</autonomy>            
+    <autonomy tags="REAL, SIL" auctioneer="false">AuctionAssign</autonomy>
   </entity>
-  
+
 </runscript>

--- a/missions/auction_assign.xml
+++ b/missions/auction_assign.xml
@@ -26,8 +26,8 @@
   <altitude_origin>300</altitude_origin>
   <show_origin>false</show_origin>
   
-  <network>GlobalNetwork</network>
-  <network name="CommsNetwork">SphereNetwork</network>
+  <network tags="SIL">GlobalNetwork</network>
+  <network tags="SIL" name="CommsNetwork">SphereNetwork</network>
   
   <entity_interaction>SimpleCollision</entity_interaction>
   
@@ -52,13 +52,12 @@
     <motion_model>SingleIntegrator</motion_model>
   </entity_common> 
 
-  <entity entity_common="auction">
-    <name>agent</name>
-    <autonomy auctioneer="true">AuctionAssign</autonomy>            
+  <entity entity_common="auction" tag="entity_1">
+    <autonomy tags="REAL, SIL" auctioneer="true">AuctionAssign</autonomy>            
   </entity>
 
-  <entity entity_common="auction">
-    <autonomy auctioneer="false">AuctionAssign</autonomy>            
+  <entity entity_common="auction" tag="entity_2">
+    <autonomy tags="REAL, SIL" auctioneer="false">AuctionAssign</autonomy>            
   </entity>
   
 </runscript>

--- a/missions/auction_assign2.xml
+++ b/missions/auction_assign2.xml
@@ -1,42 +1,42 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
-<runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"           
+<runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     name="Multiple Aircraft Takeoff">
-  
-  <run start="0.0" end="10" dt="0.1" 
-       time_warp="10" 
-       enable_gui="true" 
+
+  <run start="0.0" end="10" dt="0.1"
+       time_warp="10"
+       enable_gui="true"
        start_paused="true"/>
-  
-  <end_condition>time</end_condition> <!-- time, one_team, none-->  
-  
+
+  <end_condition>time</end_condition> <!-- time, one_team, none-->
+
   <display_progress>true</display_progress>
-  <terrain>mcmillan</terrain>  
+  <terrain>mcmillan</terrain>
   <background_color>191 191 191</background_color> <!-- Red Green Blue -->
   <gui_update_period>10</gui_update_period> <!-- milliseconds -->
-  
+
   <plot_tracks>false</plot_tracks>
   <run_metrics weights="sasc">true</run_metrics>
   <show_plugins>false</show_plugins>
-  
-  <log_dir>~/.scrimmage/logs</log_dir>  
-      
+
+  <log_dir>~/.scrimmage/logs</log_dir>
+
   <latitude_origin>35.721025</latitude_origin>
   <longitude_origin>-120.767925</longitude_origin>
   <altitude_origin>300</altitude_origin>
   <show_origin>false</show_origin>
-  
-  <network>GlobalNetwork</network>
-  <network name="CommsNetwork">SphereNetwork</network>
-  
+
+  <network tags="REAL, SIL">GlobalNetwork</network>
+  <network tags="REAL, SIL" name="CommsNetwork">SphereNetwork</network>
+
   <entity_interaction>SimpleCollision</entity_interaction>
-  
+
   <!-- uncomment "seed" and use integer for deterministic results -->
   <seed>0</seed>
-  
+
   <!-- ========================== TEAM 1 ========================= -->
   <entity_common name="auction">
-    <team_id>1</team_id> 
+    <team_id>1</team_id>
     <color>0 0 255</color>
     <count>1</count>
     <health>1</health>
@@ -46,16 +46,18 @@
     <x>0</x>
     <y>0</y>
     <z>100</z>
-    <heading>0</heading>          
+    <heading>0</heading>
     <visual_model>sea-angler</visual_model>
     <controller>SingleIntegratorControllerSimple</controller>
     <motion_model>SingleIntegrator</motion_model>
-  </entity_common> 
+  </entity_common>
 
-  <entity entity_common="auction">
-    <name>agent</name>
-    <autonomy auctioneer="true">AuctionAssign</autonomy>            
-    <autonomy auctioneer="false">AuctionAssign</autonomy>            
+  <entity tag="entity_1" entity_common="auction">
+    <autonomy tags="REAL, SIL" auctioneer="true">AuctionAssign</autonomy>
   </entity>
-  
+
+  <entity tag="entity_2" entity_common="auction">
+    <autonomy tags="REAL, SIL" auctioneer="false">AuctionAssign</autonomy>
+  </entity>
+
 </runscript>

--- a/missions/fsm-motor-schemas.xml
+++ b/missions/fsm-motor-schemas.xml
@@ -44,6 +44,7 @@
   <!--<seed>2147483648</seed>-->
 
   <entity>
+    <name>robot</name>
     <team_id>1</team_id>
     <count>1</count>
     <color>255 0 0</color>    

--- a/missions/uuv-ex1.xml
+++ b/missions/uuv-ex1.xml
@@ -3,7 +3,8 @@
 <runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     name="Straight flying">
 
-  <run start="0.0" end="1000" dt="0.008"
+  <run start="0.0" end="1000" dt="0.1"
+       motion_multiplier="12.5"
        time_warp="20"
        enable_gui="true"
        network_gui="false"
@@ -25,8 +26,6 @@
   <output_type>all</output_type>
   <show_plugins>false</show_plugins>
 
-  <metrics>SimpleCollisionMetrics</metrics>
-
   <log_dir>~/.scrimmage/logs</log_dir>
   <create_latest_dir>true</create_latest_dir>
 
@@ -37,11 +36,12 @@
   <origin_length>10</origin_length>
 
   <entity_interaction>SimpleCollision</entity_interaction>
+  <metrics tags="REAL">SimpleCollisionMetrics</metrics>
 
   <enable_screenshots min_period="1.0" start="8.3" end="15.3">false</enable_screenshots>
 
-  <network>GlobalNetwork</network>
-  <network>LocalNetwork</network>
+  <network tags="REAL">GlobalNetwork</network>
+  <network tags="REAL">LocalNetwork</network>
 
   <!-- uncomment "seed" and use integer for deterministic results -->
   <seed>2147483648</seed>
@@ -76,7 +76,8 @@
         <autonomy>Straight</autonomy>
     -->
 
-    <autonomy network_name="LocalNetwork" topic_Name="WaypointList"
+    <autonomy tags="REAL"
+              network_name="LocalNetwork" topic_Name="WaypointList"
               mode="racetrack"
               show_waypoints="true"
               waypoints="
@@ -87,17 +88,21 @@
                          "                               
               >WaypointGenerator</autonomy>
 
-    <autonomy waypointlist_network="LocalNetwork"
+    <autonomy tags="REAL"
+              waypointlist_network="LocalNetwork"
               waypoint_network="LocalNetwork">WaypointDispatcher</autonomy>
-    
-    <autonomy show_shapes="false" max_speed="25" behaviors="
+        
+    <autonomy tags="REAL"
+              show_shapes="false" max_speed="25" behaviors="
        [ AvoidEntityMS gain='1.0' sphere_of_influence='10' minimum_range='2' ]
        [ MoveToGoalMS gain='1.0' show_shapes='true' use_initial_heading='true' goal='200,200,-100']"
               >MotorSchemas</autonomy>
     
-    <controller>UUV6DOFPIDController</controller>
-    <!--<controller energy_initial="2000">UUV6DOFLinearEnergy</controller>-->
-    <motion_model write_csv="true">UUV6DOF</motion_model>
+    <controller tags="REAL"
+                >UUV6DOFPIDController</controller>
+    <controller tags="SIL" energy_initial="2000">UUV6DOFLinearEnergy</controller>
+    <motion_model tags="SIL"
+                  write_csv="true">UUV6DOF</motion_model>
 
     <visual_model>submarine</visual_model>
   </entity>

--- a/missions/uuv-ex1.xml
+++ b/missions/uuv-ex1.xml
@@ -47,8 +47,7 @@
   <seed>2147483648</seed>
 
   <!-- ========================== TEAM 1 ========================= -->
-  <entity>
-    <name>uuv_entity</name>
+  <entity tag="uuv_entity">
     <team_id>1</team_id>
     <color>77 77 255</color>
     <count>1</count>

--- a/src/common/Utilities.cpp
+++ b/src/common/Utilities.cpp
@@ -49,6 +49,19 @@ namespace fs = boost::filesystem;
 
 namespace scrimmage {
 
+std::string exec_command(const char* cmd) {
+    std::array<char, 128> buffer;
+    std::string result;
+    std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
+    if (!pipe) throw std::runtime_error("popen() failed!");
+    while (!feof(pipe.get())) {
+        if (fgets(buffer.data(), 128, pipe.get()) != nullptr) {
+            result += buffer.data();
+        }
+    }
+    return result;
+}
+
 int next_available_id(std::string name,
                       std::map<std::string, std::string> &info,
                       std::map<int, int> &id_map) {

--- a/src/common/Utilities.cpp
+++ b/src/common/Utilities.cpp
@@ -49,19 +49,6 @@ namespace fs = boost::filesystem;
 
 namespace scrimmage {
 
-std::string exec_command(const char* cmd) {
-    std::array<char, 128> buffer;
-    std::string result;
-    std::shared_ptr<FILE> pipe(popen(cmd, "r"), pclose);
-    if (!pipe) throw std::runtime_error("popen() failed!");
-    while (!feof(pipe.get())) {
-        if (fgets(buffer.data(), 128, pipe.get()) != nullptr) {
-            result += buffer.data();
-        }
-    }
-    return result;
-}
-
 int next_available_id(std::string name,
                       std::map<std::string, std::string> &info,
                       std::map<int, int> &id_map) {

--- a/src/entity/Entity.cpp
+++ b/src/entity/Entity.cpp
@@ -199,7 +199,7 @@ bool Entity::init(AttributeMap &overrides,
             std::vector<double> tf_xyz = {0.0, 0.0, 0.0};
             auto it_xyz = overrides[sensor_order_name].find("xyz");
             if (it_xyz != overrides[sensor_order_name].end()) {
-                str2vec(it_xyz->second, " ", tf_xyz, 3);
+                str2container(it_xyz->second, " ", tf_xyz, 3);
             }
             sensor->transform()->pos() << tf_xyz[0], tf_xyz[1], tf_xyz[2];
 
@@ -207,7 +207,7 @@ bool Entity::init(AttributeMap &overrides,
             std::vector<double> tf_rpy = {0.0, 0.0, 0.0};
             auto it_rpy = overrides[sensor_order_name].find("rpy");
             if (it_rpy != overrides[sensor_order_name].end()) {
-                str2vec(it_rpy->second, " ", tf_rpy, 3);
+                str2container(it_rpy->second, " ", tf_rpy, 3);
             }
             sensor->transform()->quat().set(Angles::deg2rad(tf_rpy[0]),
                                             Angles::deg2rad(tf_rpy[1]),

--- a/src/entity/Entity.cpp
+++ b/src/entity/Entity.cpp
@@ -75,7 +75,9 @@ bool Entity::init(AttributeMap &overrides,
                   FileSearchPtr &file_search,
                   RTreePtr &rtree,
                   PubSubPtr &pubsub,
-                  TimePtr &time) {
+                  TimePtr &time,
+                  const std::set<std::string> &plugin_tags,
+                  std::function<void(std::map<std::string, std::string>&)> param_override_func) {
 
     pubsub_ = pubsub;
     time_ = time;
@@ -124,8 +126,6 @@ bool Entity::init(AttributeMap &overrides,
 
     EntityPtr parent = shared_from_this();
 
-    ConfigParse config_parse;
-
     // Save entity specific params in mp reference for later use
     mp_->entity_params()[id] = info;
     mp_->ent_id_to_block_id()[id] = ent_desc_id;
@@ -133,31 +133,41 @@ bool Entity::init(AttributeMap &overrides,
     ////////////////////////////////////////////////////////////
     // motion model
     ////////////////////////////////////////////////////////////
-    if (info.count("motion_model") == 0) {
+    bool init_empty_motion_model = true;
+    if (info.count("motion_model") > 0) {
+        ConfigParse config_parse;
+        PluginStatus<MotionModel> status =
+            plugin_manager->make_plugin<MotionModel>("scrimmage::MotionModel",
+                                                     info["motion_model"],
+                                                     *file_search,
+                                                     config_parse,
+                                                     overrides["motion_model"],
+                                                     plugin_tags);
+        if (status.status == PluginStatus<MotionModel>::cast_failed) {
+            cout << "Failed to open motion model plugin: " << info["motion_model"] << endl;
+            return false;
+        } else if (status.status == PluginStatus<MotionModel>::loaded) {
+            // We have created a valid motion model
+            init_empty_motion_model = false;
+
+            motion_model_ = status.plugin;
+            motion_model_->set_state(state_);
+            motion_model_->set_parent(parent);
+            motion_model_->set_pubsub(pubsub);
+            motion_model_->set_time(time);
+            motion_model_->set_name(info["motion_model"]);
+            param_override_func(config_parse.params());
+            motion_model_->init(info, config_parse.params());
+        }
+    }
+
+    if (init_empty_motion_model) {
         motion_model_ = std::make_shared<MotionModel>();
         motion_model_->set_state(state_);
         motion_model_->set_parent(parent);
         motion_model_->set_pubsub(pubsub);
         motion_model_->set_time(time);
-        // cout << "Warning: Missing motion model tag, initializing with base class" << endl;
-    } else {
-        motion_model_ =
-            std::dynamic_pointer_cast<MotionModel>(
-                plugin_manager->make_plugin("scrimmage::MotionModel",
-                    info["motion_model"], *file_search, config_parse,
-                    overrides["motion_model"]));
-
-        if (motion_model_ == nullptr) {
-            cout << "Failed to open motion model plugin: " << info["motion_model"] << endl;
-            return false;
-        }
-
-        motion_model_->set_state(state_);
-        motion_model_->set_parent(parent);
-        motion_model_->set_pubsub(pubsub);
-        motion_model_->set_time(time);
-        motion_model_->set_name(info["motion_model"]);
-        motion_model_->init(info, config_parse.params());
+        motion_model_->set_name("BLANK");
     }
 
     ////////////////////////////////////////////////////////////
@@ -170,45 +180,47 @@ bool Entity::init(AttributeMap &overrides,
         std::to_string(sensor_ct);
 
     while (info.count(sensor_order_name) > 0) {
+        ConfigParse config_parse;
         std::string sensor_name = info[sensor_order_name];
-        SensorPtr sensor =
-            std::dynamic_pointer_cast<Sensor>(
-                plugin_manager->make_plugin("scrimmage::Sensor",
-                                            sensor_name, *file_search,
-                                            config_parse,
-                                            overrides[sensor_order_name]));
-
-        if (sensor == nullptr) {
+        PluginStatus<Sensor> status =
+            plugin_manager->make_plugin<Sensor>("scrimmage::Sensor",
+                                                sensor_name, *file_search,
+                                                config_parse,
+                                                overrides[sensor_order_name],
+                                                plugin_tags);
+        if (status.status == PluginStatus<Sensor>::cast_failed) {
             std::cout << "Failed to open sensor plugin: " << sensor_name
                       << std::endl;
             return false;
+        } else if (status.status == PluginStatus<Sensor>::loaded) {
+            SensorPtr sensor = status.plugin;
+
+            // Get sensor's offset from entity origin
+            std::vector<double> tf_xyz = {0.0, 0.0, 0.0};
+            auto it_xyz = overrides[sensor_order_name].find("xyz");
+            if (it_xyz != overrides[sensor_order_name].end()) {
+                str2vec(it_xyz->second, " ", tf_xyz, 3);
+            }
+            sensor->transform()->pos() << tf_xyz[0], tf_xyz[1], tf_xyz[2];
+
+            // Get sensor's orientation relative to entity's coordinate frame
+            std::vector<double> tf_rpy = {0.0, 0.0, 0.0};
+            auto it_rpy = overrides[sensor_order_name].find("rpy");
+            if (it_rpy != overrides[sensor_order_name].end()) {
+                str2vec(it_rpy->second, " ", tf_rpy, 3);
+            }
+            sensor->transform()->quat().set(Angles::deg2rad(tf_rpy[0]),
+                                            Angles::deg2rad(tf_rpy[1]),
+                                            Angles::deg2rad(tf_rpy[2]));
+
+            sensor->set_parent(parent);
+            sensor->set_pubsub(pubsub);
+            sensor->set_time(time);
+            sensor->set_name(sensor_name);
+            param_override_func(config_parse.params());
+            sensor->init(config_parse.params());
+            sensors_[sensor_name + std::to_string(sensor_ct)] = sensor;
         }
-
-        // Get sensor's offset from entity origin
-        std::vector<double> tf_xyz = {0.0, 0.0, 0.0};
-        auto it_xyz = overrides[sensor_order_name].find("xyz");
-        if (it_xyz != overrides[sensor_order_name].end()) {
-            str2vec(it_xyz->second, " ", tf_xyz, 3);
-        }
-        sensor->transform()->pos() << tf_xyz[0], tf_xyz[1], tf_xyz[2];
-
-        // Get sensor's orientation relative to entity's coordinate frame
-        std::vector<double> tf_rpy = {0.0, 0.0, 0.0};
-        auto it_rpy = overrides[sensor_order_name].find("rpy");
-        if (it_rpy != overrides[sensor_order_name].end()) {
-            str2vec(it_rpy->second, " ", tf_rpy, 3);
-        }
-        sensor->transform()->quat().set(Angles::deg2rad(tf_rpy[0]),
-                                 Angles::deg2rad(tf_rpy[1]),
-                                 Angles::deg2rad(tf_rpy[2]));
-
-        sensor->set_parent(parent);
-        sensor->set_pubsub(pubsub);
-        sensor->set_time(time);
-        sensor->set_name(sensor_name);
-        sensor->init(config_parse.params());
-        sensors_[sensor_name + std::to_string(sensor_ct)] = sensor;
-
         sensor_order_name = std::string("sensor") + std::to_string(++sensor_ct);
     }
 
@@ -219,14 +231,35 @@ bool Entity::init(AttributeMap &overrides,
     std::string controller_name = std::string("controller") + std::to_string(controller_ct);
 
     while (info.count(controller_name) > 0) {
-        ControllerPtr controller = init_controller(info[controller_name],
-                                                   overrides[controller_name],
-                                                   motion_model_->vars());
-        if (controller == nullptr) {
-            std::cout << "Failed to open controller plugin: " << controller_name << std::endl;
+        ConfigParse config_parse;
+        PluginStatus<Controller> status =
+            plugin_manager_->make_plugin<Controller>("scrimmage::Controller",
+                                                     info[controller_name],
+                                                     *file_search,
+                                                     config_parse,
+                                                     overrides[controller_name],
+                                                     plugin_tags);
+        if (status.status == PluginStatus<Controller>::cast_failed) {
+            std::cout << "Failed to open controller plugin: "
+                      << controller_name << std::endl;
             return false;
+        } else if (status.status == PluginStatus<Controller>::loaded) {
+            ControllerPtr controller = status.plugin;
+            controller->set_state(state_);
+
+            // The controller's variable indices should be the same as the motion
+            // model's variable indices. This will speed up copying during the
+            // simulation.
+            connect(controller->vars(), motion_model_->vars());
+
+            controller->set_parent(shared_from_this());
+            controller->set_time(time_);
+            controller->set_pubsub(pubsub_);
+            controller->set_name(info[controller_name]);
+            param_override_func(config_parse.params());
+            controller->init(config_parse.params());
+            controllers_.push_back(controller);
         }
-        controllers_.push_back(controller);
         controller_name = std::string("controller") + std::to_string(++controller_ct);
     }
 
@@ -273,32 +306,37 @@ bool Entity::init(AttributeMap &overrides,
     std::string autonomy_name = std::string("autonomy") + std::to_string(autonomy_ct);
 
     while (info.count(autonomy_name) > 0) {
-        AutonomyPtr autonomy =
-            std::dynamic_pointer_cast<Autonomy>(
-                plugin_manager->make_plugin("scrimmage::Autonomy",
-                                            info[autonomy_name], *file_search, config_parse,
-                                            overrides[autonomy_name]));
-
-        if (autonomy == nullptr) {
+        ConfigParse config_parse;
+        PluginStatus<Autonomy> status =
+            plugin_manager->make_plugin<Autonomy>("scrimmage::Autonomy",
+                                                  info[autonomy_name],
+                                                  *file_search,
+                                                  config_parse,
+                                                  overrides[autonomy_name],
+                                                  plugin_tags);
+        if (status.status == PluginStatus<Autonomy>::cast_failed) {
             cout << "Failed to open autonomy plugin: " << info[autonomy_name] << endl;
             return false;
+        } else if (status.status == PluginStatus<Autonomy>::loaded) {
+            AutonomyPtr autonomy = status.plugin;
+            // Connect the autonomy to the first controller
+            if (not controllers_.empty()) {
+                connect(autonomy->vars(), controllers_.front()->vars());
+            }
+            autonomy->set_rtree(rtree);
+            autonomy->set_parent(parent);
+            autonomy->set_projection(proj_);
+            autonomy->set_pubsub(pubsub);
+            autonomy->set_time(time);
+            autonomy->set_state(motion_model_->state());
+            autonomy->set_contacts(contacts);
+            autonomy->set_is_controlling(true);
+            autonomy->set_name(info[autonomy_name]);
+            param_override_func(config_parse.params());
+            autonomy->init(config_parse.params());
+
+            autonomies_.push_back(autonomy);
         }
-
-        // Connect the autonomy to the first controller
-        connect(autonomy->vars(), controllers_.front()->vars());
-
-        autonomy->set_rtree(rtree);
-        autonomy->set_parent(parent);
-        autonomy->set_projection(proj_);
-        autonomy->set_pubsub(pubsub);
-        autonomy->set_time(time);
-        autonomy->set_state(motion_model_->state());
-        autonomy->set_contacts(contacts);
-        autonomy->set_is_controlling(true);
-        autonomy->set_name(info[autonomy_name]);
-        autonomy->init(config_parse.params());
-
-        autonomies_.push_back(autonomy);
         autonomy_name = std::string("autonomy") + std::to_string(++autonomy_ct);
     }
 
@@ -307,7 +345,7 @@ bool Entity::init(AttributeMap &overrides,
         connect_entity = boost::lexical_cast<bool>(info["connect_entity"]);
     }
 
-    if (connect_entity) {
+    if (connect_entity && not controllers_.empty()) {
         auto verify_io = [&](auto &p) {return verify_io_connection(p->vars(), controllers_.front()->vars());};
         if (boost::algorithm::none_of(autonomies_, verify_io)) {
             auto out_it = std::ostream_iterator<std::string>(std::cout, ", ");
@@ -324,12 +362,13 @@ bool Entity::init(AttributeMap &overrides,
         }
     }
 
-    if (autonomies_.empty()) {
-        controllers_.front()->set_desired_state(state_);
-    } else {
-        controllers_.front()->set_desired_state(autonomies_.front()->desired_state());
+    if (not controllers_.empty()) {
+        if (autonomies_.empty()) {
+            controllers_.front()->set_desired_state(state_);
+        } else {
+            controllers_.front()->set_desired_state(autonomies_.front()->desired_state());
+        }
     }
-
     return true;
 }
 
@@ -466,7 +505,7 @@ void Entity::set_active(bool active) { active_ = active; }
 bool Entity::active() { return active_; }
 
 void Entity::setup_desired_state() {
-    if (!controllers_.front()) return;
+    if (controllers_.empty()) return;
 
     auto it = std::find_if(autonomies_.rbegin(), autonomies_.rend(),
         [&](auto autonomy) {return autonomy->get_is_controlling();});
@@ -548,41 +587,29 @@ std::unordered_map<std::string, MessageBasePtr> &Entity::properties() {
     return properties_;
 }
 
-ControllerPtr Entity::init_controller(
-        const std::string &name,
-        std::map<std::string, std::string> &overrides,
-        VariableIO &next_io) {
-
-    ConfigParse config_parse;
-    ControllerPtr controller =
-        std::static_pointer_cast<Controller>(
-            plugin_manager_->make_plugin("scrimmage::Controller",
-                name, *file_search_, config_parse, overrides));
-
-    if (controller == nullptr) {
-        std::cout << "Failed to open controller plugin: " << name << std::endl;
-        return nullptr;
-    }
-
-    controller->set_state(state_);
-
-    // The controller's variable indices should be the same as the motion
-    // model's variable indices. This will speed up copying during the
-    // simulation.
-    connect(controller->vars(), next_io);
-
-    controller->set_parent(shared_from_this());
-    controller->set_time(time_);
-    controller->set_pubsub(pubsub_);
-    controller->set_name(name);
-    controller->init(config_parse.params());
-    return controller;
-}
-
 void Entity::set_time_ptr(TimePtr t) {time_ = t;}
 
 // cppcheck-suppress passedByValue
 void Entity::set_projection(std::shared_ptr<GeographicLib::LocalCartesian> proj) {
     proj_ = proj;
+}
+
+void Entity::print_plugins(std::ostream &out) const {
+    out << "----------- Sensor -------------" << endl;
+    for (auto &kv : sensors_) {
+        out << kv.second->name() << endl;
+    }
+    out << "---------- Autonomy ------------" << endl;
+    for (AutonomyPtr a : autonomies_) {
+        out << a->name() << endl;
+    }
+    out << "---------- Controller ----------" << endl;
+    for (ControllerPtr c : controllers_) {
+        out << c->name() << endl;
+    }
+    out << "----------- Motion -------------" << endl;
+    if (motion_model_->name() != "BLANK") {
+        out << motion_model_->name() << endl;
+    }
 }
 } // namespace scrimmage

--- a/src/entity/External.cpp
+++ b/src/entity/External.cpp
@@ -31,6 +31,7 @@
  */
 
 #include <scrimmage/autonomy/Autonomy.h>
+#include <scrimmage/motion/MotionModel.h>
 #include <scrimmage/common/FileSearch.h>
 #include <scrimmage/common/Random.h>
 #include <scrimmage/common/RTree.h>
@@ -49,6 +50,7 @@
 
 #include <iostream>
 #include <iomanip>
+#include <set>
 
 #include <GeographicLib/Geocentric.hpp>
 #include <GeographicLib/LocalCartesian.hpp>
@@ -78,15 +80,43 @@ External::External() :
     id_to_team_map_(std::make_shared<std::unordered_map<int, int>>()),
     id_to_ent_map_(std::make_shared<std::unordered_map<int, EntityPtr>>()) {}
 
-bool External::create_entity(int max_entities, int entity_id,
-                             const std::string &entity_name,
-                             bool connect_entity) {
+void External::print_plugins(std::ostream &out) const {
+    out << "====== SCRIMMAGE Plugins Loaded =======" << endl;
+    out << "----------- Network ------------" << endl;
+    for (auto &kv : *networks_) {
+        out << kv.first << endl;
+    }
+    out << "------ Entity Interaction ------" << endl;
+    for (EntityInteractionPtr ei:  ent_inters_) {
+        out << ei->name() << endl;
+    }
+    out << "----------- Metrics ------------" << endl;
+    for (MetricsPtr m : metrics_) {
+        out << m->name() << endl;
+    }
+    entity_->print_plugins(out);
+}
 
-    if (mp_->get_mission_filename() == "") {
-        cout << "External::mp()->parse() has not been run yet, "
-            << "exiting External::create_entity()" << endl;
+bool External::create_entity(const std::string &mission_file,
+                             const std::string &entity_name,
+                             const std::string &plugin_tags_str,
+                             int entity_id,
+                             int max_entities, const std::string &log_dir,
+                             std::function<void(std::map<std::string, std::string>&)> param_override_func) {
+    // Find the mission file
+    auto found_mission_file = FileSearch().find_mission(mission_file);
+    if (not found_mission_file) {
+        cout << "Failed to load mission file: " << mission_file << endl;
         return false;
     }
+
+    // Parse the mission file
+    if (not mp_->parse(*found_mission_file)) {
+        cout << "Failed to parse mission file: " << *found_mission_file << endl;
+        return false;
+    }
+
+    setup_logging(log_dir);
 
     // Parse the entity name and find the entity block ID for the associated
     // entity name
@@ -105,8 +135,6 @@ bool External::create_entity(int max_entities, int entity_id,
 
     std::map<std::string, std::string> info =
         mp_->entity_descriptions()[it_name_id->second];
-    info.erase("motion_model"); // we don't need to initialize this
-    info["connect_entity"] = std::to_string(connect_entity);
 
     ContactMapPtr contacts = std::make_shared<ContactMap>();
     std::shared_ptr<RTree> rtree = std::make_shared<RTree>();
@@ -129,20 +157,22 @@ bool External::create_entity(int max_entities, int entity_id,
     sim_info.id_to_team_map = id_to_team_map_;
     sim_info.id_to_ent_map = id_to_ent_map_;
 
+    std::set<std::string> plugin_tags = str2set<std::string>(plugin_tags_str, ", ");
+
     networks_ = std::make_shared<NetworkMap>();
-    if (!create_networks(sim_info, *networks_)) {
+    if (!create_networks(sim_info, *networks_, plugin_tags, param_override_func)) {
         std::cout << "External::create_entity() failed on create_networks()" << std::endl;
         return false;
     }
 
     metrics_.clear();
-    if (!create_metrics(sim_info, contacts, metrics_)) {
+    if (!create_metrics(sim_info, contacts, metrics_, plugin_tags, param_override_func)) {
         std::cout << "External::create_entity() failed on create_metrics()" << std::endl;
         return false;
     }
 
     ent_inters_.clear();
-    if (!create_ent_inters(sim_info, contacts, shapes, ent_inters_)) {
+    if (!create_ent_inters(sim_info, contacts, shapes, ent_inters_, plugin_tags, param_override_func)) {
         std::cout << "External::create_entity() failed on create_ent_inters()" << std::endl;
         return false;
     }
@@ -155,13 +185,15 @@ bool External::create_entity(int max_entities, int entity_id,
         entity_->init(
             attr_map, info, contacts, mp_, mp_->projection(), entity_id,
             it_name_id->second, plugin_manager_, file_search, rtree, pubsub_,
-            time_);
+            time_, plugin_tags, param_override_func);
     if (!ent_success) {
         std::cout << "External::create_entity() failed on entity_->init()" << std::endl;
         return false;
     }
 
-    if (connect_entity) {
+    motion_dt_ = mp_->dt() * 1.0 / mp_->motion_multiplier();
+
+    if (entity_->controllers().size() > 0) {
         connect(entity_->controllers().back()->vars(), vars);
         if (!verify_io_connection(entity_->controllers().back()->vars(), vars)) {
             auto ctrl = entity_->controllers().back();
@@ -180,7 +212,9 @@ bool External::create_entity(int max_entities, int entity_id,
     return true;
 }
 
-void External::setup_logging() {
+void External::setup_logging(const std::string &log_dir) {
+    mp_->set_log_dir(log_dir);
+
     std::string output_type = get("output_type", mp_->params(), std::string("all"));
 
     mp_->create_log_dir();
@@ -218,14 +252,16 @@ bool External::step(double t) {
 
     entity_->setup_desired_state();
 
-    int num_steps = dt <= min_motion_dt ? 1 : ceil(dt / min_motion_dt);
-    double motion_dt = dt / num_steps;
+    int num_steps = std::round(dt / motion_dt_);
     double temp_t = t - dt;
     for (int i = 0; i < num_steps; i++) {
         for (ControllerPtr controller : entity_->controllers()) {
-            controller->step(temp_t, motion_dt);
+            controller->step(temp_t, motion_dt_);
         }
-        temp_t += motion_dt;
+        if (enable_motion_) {
+            entity_->motion()->step(temp_t, motion_dt_);
+        }
+        temp_t += motion_dt_;
     }
 
     if (!ent_inters_.empty()) {

--- a/src/entity/External.cpp
+++ b/src/entity/External.cpp
@@ -98,7 +98,7 @@ void External::print_plugins(std::ostream &out) const {
 }
 
 bool External::create_entity(const std::string &mission_file,
-                             const std::string &entity_name,
+                             const std::string &entity_tag,
                              const std::string &plugin_tags_str,
                              int entity_id,
                              int max_entities, const std::string &log_dir,
@@ -120,9 +120,9 @@ bool External::create_entity(const std::string &mission_file,
 
     // Parse the entity name and find the entity block ID for the associated
     // entity name
-    auto it_name_id = mp_->entity_name_to_id().find(entity_name);
-    if (it_name_id == mp_->entity_name_to_id().end()) {
-        cout << "Entity name (" << entity_name << ") not found in mission file"
+    auto it_name_id = mp_->entity_tag_to_id().find(entity_tag);
+    if (it_name_id == mp_->entity_tag_to_id().end()) {
+        cout << "Entity name (" << entity_tag << ") not found in mission file"
              << endl;
         return false;
     }
@@ -157,7 +157,7 @@ bool External::create_entity(const std::string &mission_file,
     sim_info.id_to_team_map = id_to_team_map_;
     sim_info.id_to_ent_map = id_to_ent_map_;
 
-    std::set<std::string> plugin_tags = str2set<std::string>(plugin_tags_str, ", ");
+    auto plugin_tags = str2container<std::set<std::string>>(plugin_tags_str, ", ");
 
     networks_ = std::make_shared<NetworkMap>();
     if (!create_networks(sim_info, *networks_, plugin_tags, param_override_func)) {

--- a/src/parse/MissionParse.cpp
+++ b/src/parse/MissionParse.cpp
@@ -207,7 +207,7 @@ bool MissionParse::parse(const std::string &filename) {
     bool bg_color_result = false;
     std::vector<int> temp_color;
     if (params_.count("background_color") > 0) {
-        bg_color_result = str2vec<int>(params_["background_color"], " ", temp_color, 3);
+        bg_color_result = str2container(params_["background_color"], " ", temp_color, 3);
     }
     if (bg_color_result) {
         background_color_.set_r(temp_color[0]);
@@ -512,7 +512,7 @@ bool MissionParse::parse(const std::string &filename) {
         bool color_status = false;
         std::vector<int> temp_color;
         if (script_info.count("color") > 0) {
-            color_status = str2vec(script_info["color"], " ", temp_color, 3);
+            color_status = str2container(script_info["color"], " ", temp_color, 3);
         }
 
         if (!color_status) {
@@ -544,7 +544,7 @@ bool MissionParse::parse(const std::string &filename) {
 
             // Tokenize rate based on "/"
             std::vector<double> values;
-            bool status = str2vec(script_info["generate_rate"], "/",
+            bool status = str2container(script_info["generate_rate"], "/",
                                   values, 2);
             double rate = -1;
             if (status) {
@@ -582,10 +582,11 @@ bool MissionParse::parse(const std::string &filename) {
         next_gen_times_[ent_desc_id] = start_times;
         gen_info_[ent_desc_id] = gen_info;
 
-        // If the entity block has a "name", save the mapping from entity name
-        // to entity ID
-        if (script_info.count("name")) {
-            entity_name_to_id_[script_info["name"]] = ent_desc_id;
+        // If the entity block has a "tag" attribute, save the mapping from the
+        // tag to the entity block ID
+        rapidxml::xml_attribute<> *tag_attr = script_node->first_attribute("tag");
+        if (tag_attr != 0) {
+            entity_tag_to_id_[tag_attr->value()] = ent_desc_id;
         }
 
         entity_descs_[ent_desc_id++] = script_info;
@@ -799,8 +800,8 @@ std::map<int, int> &MissionParse::ent_id_to_block_id() {
 
 EntityDesc_t &MissionParse::entity_descriptions() { return entity_descs_; }
 
-std::map<std::string, int> & MissionParse::entity_name_to_id() {
-    return entity_name_to_id_;
+std::map<std::string, int> & MissionParse::entity_tag_to_id() {
+    return entity_tag_to_id_;
 }
 
 bool MissionParse::enable_gui() { return enable_gui_; }

--- a/src/parse/ParseUtils.cpp
+++ b/src/parse/ParseUtils.cpp
@@ -133,7 +133,7 @@ bool find_model_properties(std::string model_name,
     it_info = cv_parse.params().find("visual_rpy");
     if (it_info != cv_parse.params().end()) {
         std::vector<double> temp_rotate;
-        if (str2vec<double>(it_info->second, " ", temp_rotate, 3)) {
+        if (str2container(it_info->second, " ", temp_rotate, 3)) {
             valid_rotate = true;
             for (auto it = temp_rotate.begin(); it != temp_rotate.end(); it++) {
                 cv->add_rotate(*it);

--- a/src/plugins/autonomy/AutonomyExecutor/AutonomyExecutor.cpp
+++ b/src/plugins/autonomy/AutonomyExecutor/AutonomyExecutor.cpp
@@ -125,20 +125,22 @@ void AutonomyExecutor::init(std::map<std::string, std::string> &params) {
         }
 
         sc::ConfigParse config_parse;
-        scrimmage::AutonomyPtr autonomy =
-            std::dynamic_pointer_cast<scrimmage::Autonomy>(
-                parent_->plugin_manager()->make_plugin("scrimmage::Autonomy",
-                                                       autonomy_name,
-                                                       *(parent_->file_search()),
-                                                       config_parse,
-                                                       autonomy_params));
-        if (autonomy == nullptr) {
-            cout << "Failed to load autonomy plugin: " << autonomy_name << endl;
-        } else {
+        PluginStatus<Autonomy> status =
+            parent_->plugin_manager()->make_plugin<Autonomy>("scrimmage::Autonomy",
+                                                             autonomy_name,
+                                                             *(parent_->file_search()),
+                                                             config_parse,
+                                                             autonomy_params,
+                                                             std::set<std::string>{});
+        if (status.status == PluginStatus<Autonomy>::cast_failed) {
+            cout << "AutonomyExecutor Failed to open autonomy plugin: "
+                 << autonomy_name << endl;
+        } else if (status.status == PluginStatus<Autonomy>::loaded) {
             // connect the initialized autonomy plugin's variable output with
             // the variable input to the controller. This is similar to
             // connect(autonomy->vars(), controller->vars());
             // but without the reference to the controller->vars()
+            AutonomyPtr autonomy = status.plugin;
             autonomy->vars().output_variable_index() = vars_.output_variable_index();
             autonomy->vars().set_output(vars_.output());
 

--- a/src/plugins/autonomy/WaypointGenerator/WaypointGenerator.cpp
+++ b/src/plugins/autonomy/WaypointGenerator/WaypointGenerator.cpp
@@ -67,9 +67,8 @@ WaypointGenerator::WaypointGenerator() {
 }
 
 void WaypointGenerator::init(std::map<std::string, std::string> &params) {
-    waypoint_color_ = sc::str2vec<int>(sc::get<std::string>("waypoint_color",
-                                                            params,
-                                                            "255,0,0"), ",");
+    waypoint_color_ = sc::str2container<std::vector<int>>(
+        sc::get<std::string>("waypoint_color", params, "255,0,0"), ",");
 
     show_waypoints_ = sc::get<bool>("show_waypoints", params, false);
 

--- a/src/plugins/controller/DoubleIntegratorControllerWaypoint/DoubleIntegratorControllerWaypoint.cpp
+++ b/src/plugins/controller/DoubleIntegratorControllerWaypoint/DoubleIntegratorControllerWaypoint.cpp
@@ -44,7 +44,7 @@ namespace controller {
 
 void DoubleIntegratorControllerWaypoint::init(std::map<std::string, std::string> &params) {
     std::vector<double> gain;
-    if (!scrimmage::str2vec<double>(params.at("gain"), ",", gain, 2)) {
+    if (!scrimmage::str2container(params.at("gain"), ",", gain, 2)) {
         std::cout << "warning: did not get gain properly in DoubleIntegratorControllerWaypoint" << std::endl;
     } else {
         gain_ << gain[0], gain[1];

--- a/src/plugins/interaction/MapGen2D/MapGen2D.cpp
+++ b/src/plugins/interaction/MapGen2D/MapGen2D.cpp
@@ -103,7 +103,7 @@ bool MapGen2D::init(std::map<std::string, std::string> &mission_params,
 
     // Parse wall color
     std::vector<int> color;
-    bool color_status = sc::str2vec(color_str, " ", color, 3);
+    bool color_status = sc::str2container(color_str, " ", color, 3);
     if (!color_status) {
         cout << "Warning: Failed to parse wall color." << endl;
         color = {0, 0, 255};

--- a/src/pubsub/Network.cpp
+++ b/src/pubsub/Network.cpp
@@ -62,7 +62,7 @@ bool Network::network_init(std::map<std::string, std::string> &mission_params,
                             bool &monitor_all) {
         std::string topics_str = get<std::string>(str, plugin_params, "");
 
-        std::vector<std::string> topics = str2vec<std::string>(topics_str, ", ");
+        auto topics = str2container<std::vector<std::string>>(topics_str, ", ");
 
         if (std::end(topics) != std::find(std::begin(topics),
                                           std::end(topics), "*")) {

--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -264,9 +264,9 @@ bool SimControl::init() {
     info.id_to_ent_map = id_to_ent_map_;
 
     networks_ = std::make_shared<NetworkMap>();
-    if (!create_networks(info, *networks_, std::set<std::string>{}, [](std::map<std::string, std::string>&){})) return false;
-    if (!create_metrics(info, contacts_, metrics_, std::set<std::string>{}, [](std::map<std::string, std::string>&){})) return false;
-    if (!create_ent_inters(info, contacts_, shapes_[0], ent_inters_, std::set<std::string>{}, [](std::map<std::string, std::string>&){})) return false;
+    if (!create_networks(info, *networks_)) return false;
+    if (!create_metrics(info, contacts_, metrics_)) return false;
+    if (!create_ent_inters(info, contacts_, shapes_[0], ent_inters_)) return false;
 
     // Setup simcontrol's pubsub plugin
     pub_end_time_ = sim_plugin_->advertise("GlobalNetwork", "EndTime");

--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -264,9 +264,9 @@ bool SimControl::init() {
     info.id_to_ent_map = id_to_ent_map_;
 
     networks_ = std::make_shared<NetworkMap>();
-    if (!create_networks(info, *networks_)) return false;
-    if (!create_metrics(info, contacts_, metrics_)) return false;
-    if (!create_ent_inters(info, contacts_, shapes_[0], ent_inters_)) return false;
+    if (!create_networks(info, *networks_, std::set<std::string>{}, [](std::map<std::string, std::string>&){})) return false;
+    if (!create_metrics(info, contacts_, metrics_, std::set<std::string>{}, [](std::map<std::string, std::string>&){})) return false;
+    if (!create_ent_inters(info, contacts_, shapes_[0], ent_inters_, std::set<std::string>{}, [](std::map<std::string, std::string>&){})) return false;
 
     // Setup simcontrol's pubsub plugin
     pub_end_time_ = sim_plugin_->advertise("GlobalNetwork", "EndTime");
@@ -471,7 +471,9 @@ bool SimControl::generate_entities(double t) {
             AttributeMap &attr_map = mp_->entity_attributes()[ent_desc_id];
             bool ent_status = ent->init(attr_map, params,
                 contacts_, mp_, proj_, next_id_, ent_desc_id,
-                plugin_manager_, file_search_, rtree_, pubsub_, time_);
+                plugin_manager_, file_search_, rtree_, pubsub_, time_,
+                std::set<std::string>{},
+                [](std::map<std::string, std::string>&){});
             contacts_mutex_.unlock();
 
             if (!ent_status) {

--- a/src/viewer/Updater.cpp
+++ b/src/viewer/Updater.cpp
@@ -2030,7 +2030,7 @@ void Updater::get_model_texture(std::string name,
         auto rpy_iter = c_parse.params().find("visual_rpy");
         if (rpy_iter != c_parse.params().end()) {
             std::vector<double> tf_rpy = {0.0, 0.0, 0.0};
-            str2vec(rpy_iter->second, " ", tf_rpy, 3);
+            str2container(rpy_iter->second, " ", tf_rpy, 3);
             for (auto& e : tf_rpy) {
                 e = sc::Angles::deg2rad(e);
             }

--- a/src/viewer/Viewer.cpp
+++ b/src/viewer/Viewer.cpp
@@ -133,7 +133,7 @@ bool Viewer::run() {
         get<std::string>("pos", params_, "0, 1, 200");
 
     std::vector<double> camera_pos;
-    if (!str2vec(camera_pos_str, ",", camera_pos, 3)) {
+    if (!str2container(camera_pos_str, ",", camera_pos, 3)) {
         std::cout << "camera_position should have 3 comma separated entries" << std::endl;
         return false;
     }
@@ -142,7 +142,7 @@ bool Viewer::run() {
         get<std::string>("focal_point", params_, "0, 0, 0");
 
     std::vector<double> camera_focal_pos;
-    if (!str2vec(camera_focal_pos_str, ",", camera_focal_pos, 3)) {
+    if (!str2container(camera_focal_pos_str, ",", camera_focal_pos, 3)) {
         std::cout << "camera_focal_point should have 3 comma separated entries" << std::endl;
         return false;
     }


### PR DESCRIPTION
Eric,
  I have updated the external class and plugin creation functions to use the tags attribute in all plugins to enable or disable loading of that plugin. Also, we can now override plugin parameters from a process that calls the External class' create_entity function (e.g., override scrimmage plugins with ROS parameters at initialization time).  Please take a look and let me know what you think. This commit will fail to build until I also update the scrimmage_ros package, so don't accept this merge request, but provide any feedback that you have. I will need to update the documentation for using scrimmage within a ROS nodelet as well.