### PR TITLE
update remaining plugins with no-c-linkage flag

### DIFF
--- a/src/plugins/autonomy/BoundaryDefense/CMakeLists.txt
+++ b/src/plugins/autonomy/BoundaryDefense/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(${LIBRARY_NAME} SHARED
 )
 
 target_compile_options(${LIBRARY_NAME}
-  PRIVATE -Wall -Wno-return-type-c-linkage -std=c++14 -fext-numeric-literals
+  PRIVATE -Wall -Wno-return-type-c-linkage -std=c++14
 )
 
 target_link_libraries(${LIBRARY_NAME}

--- a/src/plugins/controller/UUV6DOFLinearEnergy/CMakeLists.txt
+++ b/src/plugins/controller/UUV6DOFLinearEnergy/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(${LIBRARY_NAME} SHARED
 )
 
 target_compile_options(${LIBRARY_NAME}
-  PRIVATE -Wall -std=c++14
+  PRIVATE -Wall -std=c++14 -Wno-return-type-c-linkage
 )
 
 target_link_libraries(${LIBRARY_NAME}

--- a/src/plugins/controller/UnicyclePID/CMakeLists.txt
+++ b/src/plugins/controller/UnicyclePID/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(${LIBRARY_NAME} SHARED
 )
 
 target_compile_options(${LIBRARY_NAME}
-  PRIVATE -Wall -std=c++14
+  PRIVATE -Wall -std=c++14 -Wno-return-type-c-linkage
 )
 
 target_link_libraries(${LIBRARY_NAME}

--- a/src/plugins/sensor/NoisyContacts/CMakeLists.txt
+++ b/src/plugins/sensor/NoisyContacts/CMakeLists.txt
@@ -13,7 +13,7 @@ add_library(${LIBRARY_NAME} SHARED
 )
 
 target_compile_options(${LIBRARY_NAME}
-  PRIVATE -Wall -std=c++14
+  PRIVATE -Wall -std=c++14 -Wno-return-type-c-linkage
 )
 
 target_link_libraries(${LIBRARY_NAME}


### PR DESCRIPTION
Remove fext-numeric-literals flag that was erroneously added recently, which is unavailable in clang