### PR TITLE
add nonlearning mode to openai

### DIFF
--- a/CHANGLOG.md
+++ b/CHANGLOG.md
@@ -1,0 +1,9 @@
+Change Log
+==========
+
+2018-10
+
+* plugins inheriting from ``ScrimmageOpenAIAutonomy`` now override ``init_helper``
+  and ``step_helper`` instead of ``init`` and ``step_autonomy``.
+* To access python libraries, do ``import scrimmage.utils``, ``import
+  scrimmage.bindings``, and ``import scrimmaage.proto_utils``

--- a/ci/dockerfiles/ubuntu-16.04
+++ b/ci/dockerfiles/ubuntu-16.04
@@ -72,15 +72,23 @@ RUN /bin/bash -c "mkdir -p build && \
     cd build && \
     source ~/.scrimmage/setup.bash && \
     cmake .. -G Ninja -DBUILD_TESTS=ON -DBUILD_DOCS=ON -DCMAKE_CXX_FLAGS="-Werror" && \
-    ninja -j 3 && \
+    ninja && \
     ninja docs"
 
+# install python package and run tests
+WORKDIR /root/scrimmage/scrimmage/python
+RUN pip install -e .
+
 # run tests
-RUN /bin/bash -c "cd build && \
-    source ~/.scrimmage/setup.bash && \
+SHELL ["/bin/bash", "-c"]
+WORKDIR /root/scrimmage/scrimmage/build
+RUN source ~/.scrimmage/setup.bash && \
+    export SCRIMMAGE_MISSION_PATH=$SCRIMMAGE_MISSION_PATH:$PWD && \
+    export PYTHONPATH=$PYTHONPATH:$PWD/../test && \
+    py.test ../test/test_openai.py && \
     ninja test && \
     scrimmage ../missions/straight-no-gui.xml && \
-    scrimmage ../missions/straight_jsbsim.xml"
+    scrimmage ../missions/straight_jsbsim.xml
 
 # Test scrimmage_ros package integration
 RUN mkdir -p /root/catkin_ws/src
@@ -96,10 +104,6 @@ RUN /bin/bash -c "source /opt/ros/kinetic/setup.bash && \
     cd build && \
     make tests && \
     make test"
-
-# install python package and run tests
-WORKDIR /root/scrimmage/scrimmage/python
-RUN pip install -e .
 
 WORKDIR /root/scrimmage/scrimmage
 RUN /bin/bash -c "source ~/.scrimmage/setup.bash && py.test python/tests"

--- a/docs/source/tutorials/openai-plugin.rst
+++ b/docs/source/tutorials/openai-plugin.rst
@@ -23,25 +23,30 @@ In addition, the interface between python and scrimmage is defined in
 ``scrimmage/python/scrimmage/bindings/src/py_openai_env.h``.
 We can use the script provided with SCRIMMAGE to create these plugins (we will 
 call them something different in this tutorial). To do so,
-enter the following at the terminal: ::
+enter the following at the terminal:
 
-  $ cd /path/to/scrimmage/scripts
-  $ ./generate-plugin.sh autonomy SimpleLearner ~/scrimmage/my-scrimmage-plugins
-  $ ./generate-plugin.sh sensor MyOpenAISensor ~/scrimmage/my-scrimmage-plugins
+.. code-block:: bash
+
+  cd /path/to/scrimmage/scripts 
+  ./generate-plugin.sh autonomy SimpleLearner ~/scrimmage/my-scrimmage-plugins
+  ./generate-plugin.sh sensor MyOpenAISensor ~/scrimmage/my-scrimmage-plugins
 
 Now, let's build the plugins that was placed in the my-scrimmage-plugins
-project: ::
+project:
 
-  $ cd ~/scrimmage/my-scrimmage-plugins/build
-  $ cmake ..
-  $ make
+.. code-block:: bash
+
+  cd ~/scrimmage/my-scrimmage-plugins/build
+  cmake ..
+  make
+  source ~/.scrimmage/setup.bash # you probably already did this step
 
 If the plugin built successfuly, you will see the following output: ::
 
   [ 50%] Built target MyOpenAISensor_plugin
   [100%] Built target SimpleLearner
 
-In general, the scrimmage openai interface allows you to customize the environment
+In general, the SCRIMMAGE openai interface allows you to customize the environment
 in the following ways:
 
     * n agents - The most common scenario is 1 agent but SCRIMMAGE also
@@ -53,7 +58,7 @@ in the following ways:
     * Action/Observation space - this can be discrete, continuous, or combined
       (the latter would a a ``TupleSpace`` in openai).
 
-For a demonstration of these basic combinations, see ``test/test_openai.py``. 
+For a demonstration of these combinations, see ``test/test_openai.py``. 
 For this tutorial, we will only be investigating how to develop a discrete
 action space and a continuous observation space.
 
@@ -69,7 +74,11 @@ with OpenAI. Let's start with the header file located at
 
 Normal autonomy plugins extend the Autonomy class. For the OpenAI autonomy
 plugin, we will instead extend the ``ScrimmageOpenAIAutonomy`` autonomy plugin.
-In addition to the normal ``init`` and ``step_autonomy`` virtual methods,
+In this case, the ``init`` and ``step_autonomy`` functions become ``init_helper``
+and ``step_helper`` (the base class will handle the ``init`` and ``step_autonomy`` 
+functions and will call these methods). These methods can be treated similarly
+to ``init`` and ``step_autonomy`` and exist so that the user can switch
+between a learning and non-learning mode seamlessly. In addition,
 ``ScrimmageOpenAIAutonomy`` defines some extra components:
 
     * ``reward_range`` - this setting maps directly to an openai environment's
@@ -101,6 +110,9 @@ Here is the include file for ``SimpleLearner``:
 .. code-block:: c++
    :linenos:
 
+   #ifndef INCLUDE_MY_SCRIMMAGE_PLUGINS_PLUGINS_AUTONOMY_SIMPLELEARNER_SIMPLELEARNER_H_
+   #define INCLUDE_MY_SCRIMMAGE_PLUGINS_PLUGINS_AUTONOMY_SIMPLELEARNER_SIMPLELEARNER_H_
+
    #include <scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/ScrimmageOpenAIAutonomy.h>
 
    #include <map>
@@ -109,21 +121,22 @@ Here is the include file for ``SimpleLearner``:
 
    class SimpleLearner : public scrimmage::autonomy::ScrimmageOpenAIAutonomy {
     public:
-       void init(std::map<std::string, std::string> &params) override;
-       bool step_autonomy(double t, double dt) override;
+       void init_helper(std::map<std::string, std::string> &params) override;
+       bool step_helper() override;
 
        void set_environment() override;
-       std::pair<bool, double> calc_reward(double t, double dt) override;
+       std::pair<bool, double> calc_reward() override;
 
     protected:
        double radius_;
        uint8_t output_vel_x_idx_ = 0;
    };
 
+   #endif // INCLUDE_MY_SCRIMMAGE_PLUGINS_PLUGINS_AUTONOMY_SIMPLELEARNER_SIMPLELEARNER_H_
 
-Note that we are overriding the normal two virtual functions of ``init``
-and ``step_autonomy`` but in addition we will override ``set_environment``
-and ``calc_reward``.
+
+Note that we are overriding four virtual functions: ``init_helper``,
+``step_helper``, ``set_environment``, and ``calc_reward``.
 
 OpenAI Autonomy Plugin Source File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -149,7 +162,7 @@ Next, let us look at the ``init``:
 .. code-block:: c++
    :linenos:
 
-   void SimpleLearner::init(std::map<std::string, std::string> &params) {
+   void SimpleLearner::init_helper(std::map<std::string, std::string> &params) {
        using Type = scrimmage::VariableIO::Type;
        using Dir = scrimmage::VariableIO::Direction;
 
@@ -162,8 +175,6 @@ Next, let us look at the ``init``:
        vars_.output(output_vel_z_idx, 0);
 
        radius_ = std::stod(params.at("radius"));
-
-       ScrimmageOpenAIAutonomy::init(params);
    }
 
 We now define the environment:
@@ -183,7 +194,7 @@ We now define the ``calc_reward`` function:
 .. code-block:: c++
    :linenos:
 
-   std::pair<bool, double> SimpleLearner::calc_reward(double /*t*/, double /*dt*/) {
+   std::pair<bool, double> SimpleLearner::calc_reward() {
        const bool done = false;
        const double x = state_->pos()(0);
        const bool within_radius = std::round(std::abs(x)) < radius_;
@@ -192,14 +203,14 @@ We now define the ``calc_reward`` function:
    }
 
 This says that the autonomy is never going to end the simulation and gives
-a reward for being within ``1`` of the origin. We now define ``step_autonomy``
+a reward for being within the ``radius`` of the origin. We now define ``step_helper``
 to handle actions given from python. It will have positive x-velocity
 when the action is 1 and negative x-velocity when the action is 0:
 
 .. code-block:: c++
    :linenos:
 
-   bool SimpleLearner::step_autonomy(double /*t*/, double /*dt*/) {
+   bool SimpleLearner::step_helper() {
        const double x_vel = action.discrete[0] ? 1 : -1;
        vars_.output(output_vel_x_idx_, x_vel);
        return true;
@@ -236,13 +247,24 @@ The following is the parameter file for ``SimpleLearner``:
     <params>
       <library>SimpleLearner_plugin</library>
       <radius>2</radius>
+      <module>my_openai</module>
+      <actor_func>get_action</actor_func>
     </params>
         
-From here, we can now build the project::
+``module`` and ``actor_func`` exist so that we can
+call our learner outside the OpenAI environment. This is useful 
+in case we want to train using python and then do a lot of runs
+to test/verify what has been learned.
+We will discuss this later in :ref:`non-learning-mode`.
 
-  $ cd ~/scrimmage/my-scrimmage-plugins/build
-  $ cmake ..
-  $ make
+From here, we can now build the project:
+
+.. code-block:: bash
+   :linenos:
+
+   cd ~/scrimmage/my-scrimmage-plugins/build
+   cmake ..
+   make
 
 Rewrite the Sensor Plugin
 -------------------------
@@ -279,6 +301,9 @@ and overrides two virtual methods:
 .. code-block:: c++
    :linenos:
 
+   #ifndef INCLUDE_MY_SCRIMMAGE_PLUGINS_PLUGINS_SENSOR_MYOPENAISENSOR_MYOPENAISENSOR_H_
+   #define INCLUDE_MY_SCRIMMAGE_PLUGINS_PLUGINS_SENSOR_MYOPENAISENSOR_MYOPENAISENSOR_H_
+
    #include <scrimmage/plugins/sensor/ScrimmageOpenAISensor/ScrimmageOpenAISensor.h>
 
    #include <map>
@@ -290,6 +315,8 @@ and overrides two virtual methods:
        void set_observation_space() override;
        void get_observation(double* data, uint32_t beg_idx, uint32_t end_idx) override;
    };
+
+   #endif // INCLUDE_MY_SCRIMMAGE_PLUGINS_PLUGINS_SENSOR_MYOPENAISENSOR_MYOPENAISENSOR_H_
 
 OpenAI Sensor Plugin Source File
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -353,7 +380,7 @@ OpenAI Mission XML File
 
 Now that our code for SCRIMMGAE has been compiled, we can then create a simple
 mission xml file for it. We will save this xml at:
-``~/scrimmage/my-scrimmage-plugins/missions/openai.xml``.
+``~/scrimmage/my-scrimmage-plugins/missions/openai_mission.xml``.
 
 To create the environment as we described above, the mission xml would need the
 following blocks (More detail on creating mission files is located at
@@ -362,35 +389,62 @@ following blocks (More detail on creating mission files is located at
 .. code-block:: xml
    :linenos:
 
-    <entity_common name="all">
-        <count>1</count>
-        <health>1</health>
-        <radius>1</radius>
-
-        <team_id>1</team_id>
-        <visual_model>Sphere</visual_model>
-        <motion_model>SingleIntegrator</motion_model>
-        <controller>SingleIntegratorControllerSimple</controller>
-        <sensor order="0">MyOpenAISensor</sensor>
-        <autonomy
-          discrete_x="true"
-          discrete_y="true"
-          ctrl_y="false">SimpleLearner</autonomy>
-        <y>0</y>
-        <z>0</z>
-    </entity_common>
-
-    <entity entity_common="all">
-      <x>0</x>
-      <color>77 77 255</color>
-    </entity>
-
+   <?xml version="1.0"?>
+   <?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
+   <runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       name="Straight flying">
+   
+     <run start="0.0" end="100" dt="1"
+          time_warp="10"
+          enable_gui="true"
+          network_gui="false"
+          start_paused="true"/>
+   
+     <stream_port>50051</stream_port>
+     <stream_ip>localhost</stream_ip>
+   
+     <end_condition>time</end_condition> <!-- time, one_team, none-->
+   
+     <grid_spacing>1</grid_spacing>
+     <grid_size>1000</grid_size>
+   
+     <gui_update_period>10</gui_update_period> <!-- milliseconds -->
+   
+     <output_type>summary</output_type>
+     <metrics order="0">OpenAIRewards</metrics>
+   
+     <background_color>191 191 191</background_color> <!-- Red Green Blue -->
+     <log_dir>~/.scrimmage/logs</log_dir>
+   
+     <entity_common name="all">
+          <count>1</count>
+          <health>1</health>
+          <radius>1</radius>
+   
+          <team_id>1</team_id>
+          <visual_model>Sphere</visual_model>
+          <motion_model>SingleIntegrator</motion_model>
+          <controller>SingleIntegratorControllerSimple</controller>
+          <sensor order="0">MyOpenAISensor</sensor>
+          <autonomy>SimpleLearner</autonomy>
+          <y>0</y>
+          <z>0</z>
+      </entity_common>
+   
+      <entity entity_common="all">
+        <x>0</x>
+        <color>77 77 255</color>
+      </entity>
+   
+   </runscript>
 
 Now we have completed our work on the SCRIMMAGE side. Now all that is left is to
 write the python code to run our OpenAI environment.
 
-OpenAI Python File
-------------------
+.. _learning-mode:
+
+Running The OpenAI Environment
+------------------------------
 
 The following python code will create a scrimmage environment, using the mission
 file we create above. It will then do a simple environment test by stepping
@@ -398,56 +452,106 @@ through the environment and keeping track of the observations. It also sends
 a straight ahead action for the first 100 timesteps and afterwards sends a turn
 right action. At the end, it closes the environment and prints out the total
 reward. We will save this python file at
-``~/scrimmage/my-scrimmage-plugins/test/test_openai.py``.
+``~/scrimmage/my-scrimmage-plugins/my_openai.py``. 
+
 
 .. code-block:: python
    :linenos:
 
    import copy
    import gym
-   import scrimmage
-
-
+   import scrimmage.utils
+   import random
+   
+   
+   def get_action(obs):
+       return random.randint(0, 1)
+   
+   
    def test_openai():
        try:
            env = gym.make('scrimmage-v0')
        except gym.error.Error:
-           mission_file = scrimmage.find_mission('rlsimple.xml')
-
+           mission_file = scrimmage.utils.find_mission('openai_mission.xml')
+   
            gym.envs.register(
                id='scrimmage-v0',
-               entry_point='scrimmage:ScrimmageOpenAIEnv',
+               entry_point='scrimmage.bindings:ScrimmageOpenAIEnv',
                max_episode_steps=1e9,
                reward_threshold=1e9,
-               kwargs={"enable_gui": True,
+               kwargs={"enable_gui": False,
                        "mission_file": mission_file}
            )
            env = gym.make('scrimmage-v0')
-
+   
        # the observation is the x position of the vehicle
        # note that a deepcopy is used when a history
        # of observations is desired. This is because
        # the sensor plugin edits the data in-place
        obs = []
-       obs.append(copy.deepcopy(env.reset()))
+       temp_obs = copy.deepcopy(env.reset())
+       obs.append(temp_obs)
        total_reward = 0
        for i in range(200):
-
-           action = 1 if i < 100 else 0
+   
+           action = get_action(temp_obs)
            temp_obs, reward, done = env.step(action)[:3]
            obs.append(copy.deepcopy(temp_obs))
            total_reward += reward
-
+   
            if done:
                break
-
+   
        env.close()
        print("Total Reward: %2.2f" % total_reward)
-
+   
    if __name__ == '__main__':
        test_openai()
 
+If you haven't done
+so already, source the environment setup file. Otherwise it won't find
+the mission below:
+
+.. code-block:: bash
+
+   source ~/.scrimmage/setup.bash # you probably already did this step
+  
 Now that we have completed all of the code, we can simply type the following
 into the terminal to see it run! ::
 
-  $ python test_openai.py
+  $ python my_openai.py
+
+
+.. _non-learning-mode:
+
+Run In Non-learning Mode
+------------------------
+
+In :ref:`learning-mode` we ran an OpenAI environment using
+the newly defined environments from SCRIMMAGE. If `my_openai.py`
+had done something with the data from the environment,
+it may have learned something useful and you may want
+to now test/validate what has been learned
+using for instance :ref:`multiple_local_runs`.
+In other words, we want to be able to run this line::
+
+   $ scrimmage missions/openai_mission.xml
+
+as well as ::
+
+   $ python my_openai.py
+
+Because you placed the ``module`` and ``actor_func`` in your 
+``SimpleLearner.xml`` file, SCRIMMAGE knows where to find 
+what it needs.
+
+.. code-block:: bash
+
+   $ scrimmage missions/openai_mission.xml
+   [>                                                                     ] 0 %
+   ================================================================================
+   OpenAIRewards
+   ================================================================================
+   Reward for id 1 = 20
+   Simulation Complete
+

--- a/include/scrimmage/common/CSV.h
+++ b/include/scrimmage/common/CSV.h
@@ -69,7 +69,7 @@ class CSV {
 
     void set_no_value_string(const std::string &str);
 
-    int rows();
+    size_t rows();
 
     double at(int row, const std::string &header);
 

--- a/include/scrimmage/common/Visibility.h
+++ b/include/scrimmage/common/Visibility.h
@@ -30,24 +30,33 @@
  *
  */
 
-#ifndef INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
-#define INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
+#ifndef INCLUDE_SCRIMMAGE_COMMON_VISIBILITY_H_
+#define INCLUDE_SCRIMMAGE_COMMON_VISIBILITY_H_
 
-#include <scrimmage/plugins/autonomy/RLSimple/RLSimple.h>
+// https://gcc.gnu.org/wiki/Visibility
+#if defined _WIN32 || defined __CYGWIN__
+  #ifdef BUILDING_DLL
+    #ifdef __GNUC__
+      #define DLL_PUBLIC __attribute__ ((dllexport))
+    #else
+      #define DLL_PUBLIC __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
+    #endif
+  #else
+    #ifdef __GNUC__
+      #define DLL_PUBLIC __attribute__ ((dllimport))
+    #else
+      #define DLL_PUBLIC __declspec(dllimport) // Note: actually gcc seems to also supports this syntax.
+    #endif
+  #endif
+  #define DLL_LOCAL
+#else
+  #if __GNUC__ >= 4
+    #define DLL_PUBLIC __attribute__ ((visibility ("default")))
+    #define DLL_LOCAL  __attribute__ ((visibility ("hidden")))
+  #else
+    #define DLL_PUBLIC
+    #define DLL_LOCAL
+  #endif
+#endif
 
-#include <map>
-#include <string>
-#include <utility>
-
-namespace scrimmage {
-namespace autonomy {
-
-class RLConsensus : public scrimmage::autonomy::RLSimple {
- public:
-    void set_environment() override;
-    std::pair<bool, double> calc_reward() override;
-};
-} // namespace autonomy
-} // namespace scrimmage
-
-#endif // INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
+#endif // INCLUDE_SCRIMMAGE_COMMON_VISIBILITY_H_

--- a/include/scrimmage/metrics/Metrics.h
+++ b/include/scrimmage/metrics/Metrics.h
@@ -63,11 +63,14 @@ class Metrics : public Plugin{
 
     virtual std::map<int, double> & team_scores();
 
+    bool get_print_team_summary() {return print_team_summary_;}
+
  protected:
     std::string weights_file_;
     std::map<int, std::map<std::string, double>> team_metrics_;
     std::map<int, double> team_scores_;
     std::list<std::string> headers_;
+    bool print_team_summary_ = true;
 };
 
 using MetricsPtr = std::shared_ptr<Metrics>;

--- a/include/scrimmage/plugins/autonomy/RLSimple/RLSimple.h
+++ b/include/scrimmage/plugins/autonomy/RLSimple/RLSimple.h
@@ -44,11 +44,11 @@ namespace autonomy {
 
 class RLSimple : public ScrimmageOpenAIAutonomy {
  public:
-    void init(std::map<std::string, std::string> &params) override;
-    bool step_autonomy(double t, double dt) override;
+    void init_helper(std::map<std::string, std::string> &params) override;
+    bool step_helper() override;
 
     void set_environment() override;
-    std::pair<bool, double> calc_reward(double t, double dt) override;
+    std::pair<bool, double> calc_reward() override;
 
  protected:
     double radius_;

--- a/include/scrimmage/plugins/autonomy/RLSimple/RLSimple.xml
+++ b/include/scrimmage/plugins/autonomy/RLSimple/RLSimple.xml
@@ -8,4 +8,7 @@
 
   <ctrl_y>false</ctrl_y>
   <y_discrete>false</y_discrete>
+
+  <module>test_openai</module>
+  <actor_func>get_action_test_two_not_combined_veh_dim_discrete</actor_func>
 </params>

--- a/include/scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIActions.h
+++ b/include/scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIActions.h
@@ -30,24 +30,37 @@
  *
  */
 
-#ifndef INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
-#define INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
+#ifndef INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SCRIMMAGEOPENAIAUTONOMY_OPENAIACTIONS_H_
+#define INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SCRIMMAGEOPENAIAUTONOMY_OPENAIACTIONS_H_
 
-#include <scrimmage/plugins/autonomy/RLSimple/RLSimple.h>
+#include <pybind11/pybind11.h>
 
-#include <map>
-#include <string>
-#include <utility>
+#include <scrimmage/common/Visibility.h>
+
+#include <vector>
+#include <memory>
 
 namespace scrimmage {
 namespace autonomy {
 
-class RLConsensus : public scrimmage::autonomy::RLSimple {
+class ScrimmageOpenAIAutonomy;
+
+class DLL_PUBLIC OpenAIActions {
  public:
-    void set_environment() override;
-    std::pair<bool, double> calc_reward() override;
+    OpenAIActions();
+    std::vector<std::shared_ptr<ScrimmageOpenAIAutonomy>> &ext_ctrl_vec();
+    void create_action_space(bool combine_actors);
+    void distribute_action(pybind11::object action, bool combine_actors);
+
+    pybind11::object action_space;
+
+ protected:
+    std::vector<std::shared_ptr<ScrimmageOpenAIAutonomy>> ext_ctrl_vec_;
+    pybind11::object tuple_space_;
+    pybind11::object box_space_;
+    pybind11::object asarray_;
 };
+
 } // namespace autonomy
 } // namespace scrimmage
-
-#endif // INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
+#endif // INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SCRIMMAGEOPENAIAUTONOMY_OPENAIACTIONS_H_

--- a/include/scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIObservations.h
+++ b/include/scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIObservations.h
@@ -1,0 +1,87 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @date 31 July 2017
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#ifndef INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SCRIMMAGEOPENAIAUTONOMY_OPENAIOBSERVATIONS_H_
+#define INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SCRIMMAGEOPENAIAUTONOMY_OPENAIOBSERVATIONS_H_
+
+#include <pybind11/pybind11.h>
+
+#include <scrimmage/common/Visibility.h>
+
+#include <string>
+#include <vector>
+#include <unordered_map>
+
+namespace scrimmage {
+
+class Sensor;
+using SensorPtr = std::shared_ptr<Sensor>;
+
+namespace sensor {
+class ScrimmageOpenAISensor;
+}
+
+namespace autonomy {
+
+class DLL_PUBLIC OpenAIObservations {
+ public:
+    OpenAIObservations();
+
+    void create_observation_space(size_t num_entities);
+    pybind11::object update_observation(size_t num_entities);
+
+    std::vector<std::vector<std::shared_ptr<sensor::ScrimmageOpenAISensor>>> &ext_sensor_vec() {return ext_sensor_vec_;}
+
+    void add_sensors(const std::unordered_map<std::string, SensorPtr> &sensors);
+
+    pybind11::object observation_space;
+    pybind11::object observation;
+
+    void set_global_sensor(bool global_sensor) {global_sensor_ = global_sensor;}
+    bool get_global_sensor() const {return global_sensor_;}
+
+    void set_combine_actors(bool combine_actors) {combine_actors_ = combine_actors;}
+    bool get_combine_actors() const {return combine_actors_;}
+
+ protected:
+    std::vector<std::vector<std::shared_ptr<sensor::ScrimmageOpenAISensor>>> ext_sensor_vec_;
+
+    pybind11::object tuple_space_;
+    pybind11::object box_space_;
+
+    bool combine_actors_ = false;
+    bool global_sensor_ = false;
+};
+} // namespace autonomy
+} // namespace scrimmage
+
+#endif // INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SCRIMMAGEOPENAIAUTONOMY_OPENAIOBSERVATIONS_H_

--- a/include/scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIUtils.h
+++ b/include/scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIUtils.h
@@ -30,24 +30,35 @@
  *
  */
 
-#ifndef INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
-#define INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
+#ifndef INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SCRIMMAGEOPENAIAUTONOMY_OPENAIUTILS_H_
+#define INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SCRIMMAGEOPENAIAUTONOMY_OPENAIUTILS_H_
 
-#include <scrimmage/plugins/autonomy/RLSimple/RLSimple.h>
+#include <pybind11/pybind11.h>
 
-#include <map>
-#include <string>
+#include <scrimmage/common/Visibility.h>
+
 #include <utility>
+#include <string>
+#include <vector>
 
 namespace scrimmage {
+
 namespace autonomy {
 
-class RLConsensus : public scrimmage::autonomy::RLSimple {
- public:
-    void set_environment() override;
-    std::pair<bool, double> calc_reward() override;
-};
+pybind11::object DLL_PUBLIC get_gym_space(const std::string &type);
+
+void DLL_PUBLIC to_continuous(
+        std::vector<std::pair<double, double>> &p,
+        pybind11::list &minima,
+        pybind11::list &maxima);
+
+void DLL_PUBLIC to_discrete(std::vector<double> &p, pybind11::list &maxima);
+
+pybind11::object DLL_PUBLIC create_space(
+        pybind11::list discrete_maxima,
+        pybind11::list continuous_minima,
+        pybind11::list continuous_maxima);
 } // namespace autonomy
 } // namespace scrimmage
 
-#endif // INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
+#endif // INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SCRIMMAGEOPENAIAUTONOMY_OPENAIUTILS_H_

--- a/include/scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/ScrimmageOpenAIAutonomy.h
+++ b/include/scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/ScrimmageOpenAIAutonomy.h
@@ -34,6 +34,11 @@
 #define INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SCRIMMAGEOPENAIAUTONOMY_SCRIMMAGEOPENAIAUTONOMY_H_
 
 #include <scrimmage/autonomy/Autonomy.h>
+#include <scrimmage/common/Visibility.h>
+#include <scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIObservations.h>
+#include <scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIActions.h>
+
+#include <pybind11/pybind11.h>
 
 #include <map>
 #include <vector>
@@ -54,20 +59,32 @@ struct EnvValues {
 
 namespace autonomy {
 
-class ScrimmageOpenAIAutonomy : public scrimmage::Autonomy {
+class DLL_PUBLIC ScrimmageOpenAIAutonomy : public scrimmage::Autonomy {
  public:
     ScrimmageOpenAIAutonomy();
 
     // normal overrides
-    void init(std::map<std::string, std::string> &params) override;
-    bool step_autonomy(double t, double dt) override;
+    void init(std::map<std::string, std::string> &params) final;
+    bool step_autonomy(double t, double dt) final;
 
-    // additional override
+    // new overrides
+    virtual void init_helper(std::map<std::string, std::string> &/*params*/) {}
+    virtual bool step_helper() {return true;}
+
     virtual void set_environment() {}
-    virtual std::pair<bool, double> calc_reward(double t, double dt);
+    virtual std::pair<bool, double> calc_reward();
     std::pair<double, double> reward_range;
     EnvParams action_space;
     EnvValues action;
+
+ private:
+    // nonlearning mode variables
+    bool first_step_ = true;
+    PublisherPtr pub_reward_;
+    pybind11::object actor_func_;
+    bool nonlearning_mode_ = false;
+    OpenAIObservations observations_;
+    OpenAIActions actions_;
 };
 } // namespace autonomy
 } // namespace scrimmage

--- a/include/scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/ScrimmageOpenAIAutonomy.xml
+++ b/include/scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/ScrimmageOpenAIAutonomy.xml
@@ -2,4 +2,6 @@
 <?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
 <params>
   <library>ScrimmageOpenAIAutonomy_plugin</library>
+  <module>my_module</module>
+  <actor_func>my_func</actor_func>
 </params>

--- a/include/scrimmage/plugins/metrics/OpenAIRewards/OpenAIRewards.h
+++ b/include/scrimmage/plugins/metrics/OpenAIRewards/OpenAIRewards.h
@@ -30,24 +30,31 @@
  *
  */
 
-#ifndef INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
-#define INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
+#ifndef INCLUDE_SCRIMMAGE_PLUGINS_METRICS_OPENAIREWARDS_OPENAIREWARDS_H_
+#define INCLUDE_SCRIMMAGE_PLUGINS_METRICS_OPENAIREWARDS_OPENAIREWARDS_H_
 
-#include <scrimmage/plugins/autonomy/RLSimple/RLSimple.h>
+#include <scrimmage/metrics/Metrics.h>
 
 #include <map>
 #include <string>
-#include <utility>
 
 namespace scrimmage {
-namespace autonomy {
+namespace metrics {
 
-class RLConsensus : public scrimmage::autonomy::RLSimple {
+class OpenAIRewards : public scrimmage::Metrics {
  public:
-    void set_environment() override;
-    std::pair<bool, double> calc_reward() override;
-};
-} // namespace autonomy
-} // namespace scrimmage
+    OpenAIRewards();
+    std::string name() override {return std::string("OpenAIRewards");}
+    void init(std::map<std::string, std::string> &params) override;
+    bool step_metrics(double /*t*/, double /*dt*/) override {return true;}
+    void print_team_summaries() override;
+    void calc_team_scores() override;
 
-#endif // INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_RLCONSENSUS_RLCONSENSUS_H_
+ protected:
+    std::map<std::string, std::string> params_;
+    std::map<size_t, double> rewards_;
+};
+
+} // namespace metrics
+} // namespace scrimmage
+#endif // INCLUDE_SCRIMMAGE_PLUGINS_METRICS_OPENAIREWARDS_OPENAIREWARDS_H_

--- a/include/scrimmage/plugins/metrics/OpenAIRewards/OpenAIRewards.xml
+++ b/include/scrimmage/plugins/metrics/OpenAIRewards/OpenAIRewards.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
+<params>
+  <library>OpenAIRewards_plugin</library>
+
+  <!-- weights for scoring function -->
+  <ground_collisions>-1.0</ground_collisions>
+  
+</params>

--- a/include/scrimmage/simcontrol/SimUtils.h
+++ b/include/scrimmage/simcontrol/SimUtils.h
@@ -88,7 +88,7 @@ void print_io_error(const std::string &in_name, VariableIO &v);
 
 bool verify_io_connection(VariableIO &output_plugin, VariableIO &input_plugin);
 
-boost::optional<std::string> run_test(std::string mission);
+boost::optional<std::string> run_test(std::string mission, bool init_python = true);
 
 bool logging_logic(MissionParsePtr mp, std::string s);
 

--- a/missions/rlsimple.xml
+++ b/missions/rlsimple.xml
@@ -20,7 +20,7 @@
   <gui_update_period>10</gui_update_period> 
 
   <plot_tracks>false</plot_tracks>
-  <output_type>nothing</output_type>
+  <output_type>summary</output_type>
   <display_progress>false</display_progress>
   <show_plugins>false</show_plugins>
 
@@ -38,6 +38,8 @@
   <!--   timeout="5">ExternalControlInteraction</entity_interaction> -->
 
   <seed>3361078855</seed>
+  <network>GlobalNetwork</network>
+  <metrics>OpenAIRewards</metrics>
 
   <entity_common name="all">
       <count>1</count>

--- a/python/scrimmage/__init__.py
+++ b/python/scrimmage/__init__.py
@@ -28,6 +28,3 @@
 # @section DESCRIPTION
 # A Long description goes here.
 #
-#
-from scrimmage.bindings import *
-from scrimmage.utils import *

--- a/python/scrimmage/proto_utils.py
+++ b/python/scrimmage/proto_utils.py
@@ -1,0 +1,79 @@
+"""Utilities for interacting with data.
+
+@file
+
+@section LICENSE
+
+Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+
+This file is part of SCRIMMAGE.
+
+  SCRIMMAGE is free software: you can redistribute it and/or modify it under
+  the terms of the GNU Lesser General Public License as published by the
+  Free Software Foundation, either version 3 of the License, or (at your
+  option) any later version.
+
+  SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+  ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+  FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+  License for more details.
+
+  You should have received a copy of the GNU Lesser General Public License
+  along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+
+@author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+@author Eric Squires <eric.squires@gtri.gatech.edu>
+@date 31 July 2017
+@version 0.1.0
+@brief Brief file description.
+@section DESCRIPTION
+A Long description goes here.
+"""
+from scrimmage.proto import Frame_pb2
+import google.protobuf.internal.decoder
+
+
+def read_frames(frames_file, to_dataframe=False):
+    """Return a list of frames from a protobuf binary file.
+
+    The protobuf frames file is a series of frames (see here:
+    https://developers.google.com/protocol-buffers/docs/techniques#streaming)
+    which exist because we need to save multiple frames to a single file.
+    Unfortunately, python bindings are not documented/available so we
+    need to use the google protobuf internals. The message format is
+    "size of message, message".
+
+    See here for implementation details:
+    http://stackoverflow.com/a/21772949
+    https://groups.google.com/forum/#!msg/protobuf/4RydUI1HkSM/oHdYdKQ1h5kJ
+
+    The first link contains the code used below with the exception that decoder
+    is _DecodeVarint32, found at the 2nd link
+    """
+    with open(frames_file, 'rb') as f:
+        data = f.read()
+
+    frames = []
+    next_pos, pos = 0, 0
+
+    while True:
+
+        try:
+            next_pos, pos = \
+                google.protobuf.internal.decoder._DecodeVarint32(data, pos)
+        except IndexError:
+            break
+
+        frame = Frame_pb2.Frame()
+
+        try:
+            frame.ParseFromString(data[pos:pos + next_pos])
+        except:
+            print('Error reading frames! Aborting data read-in.')
+            break
+
+        frames.append(frame)
+
+        pos += next_pos
+
+    return frames

--- a/python/scrimmage/utils.py
+++ b/python/scrimmage/utils.py
@@ -41,54 +41,6 @@ try:
     import matplotlib.pyplot as plt
 except ImportError:
     pass
-import google.protobuf.internal.decoder
-
-from scrimmage.proto import Frame_pb2
-
-def read_frames(frames_file, to_dataframe=False):
-    """Return a list of frames from a protobuf binary file.
-
-    The protobuf frames file is a series of frames (see here:
-    https://developers.google.com/protocol-buffers/docs/techniques#streaming)
-    which exist because we need to save multiple frames to a single file.
-    Unfortunately, python bindings are not documented/available so we
-    need to use the google protobuf internals. The message format is
-    "size of message, message".
-
-    See here for implementation details:
-    http://stackoverflow.com/a/21772949
-    https://groups.google.com/forum/#!msg/protobuf/4RydUI1HkSM/oHdYdKQ1h5kJ
-
-    The first link contains the code used below with the exception that decoder
-    is _DecodeVarint32, found at the 2nd link
-    """
-    with open(frames_file, 'rb') as f:
-        data = f.read()
-
-    frames = []
-    next_pos, pos = 0, 0
-
-    while True:
-
-        try:
-            next_pos, pos = \
-                google.protobuf.internal.decoder._DecodeVarint32(data, pos)
-        except IndexError:
-            break
-
-        frame = Frame_pb2.Frame()
-
-        try:
-            frame.ParseFromString(data[pos:pos + next_pos])
-        except:
-            print('Error reading frames! Aborting data read-in.')
-            break
-
-        frames.append(frame)
-
-        pos += next_pos
-
-    return frames
 
 
 def find_mission(fname):

--- a/scripts/my_module.py
+++ b/scripts/my_module.py
@@ -1,0 +1,2 @@
+
+print('hello world')

--- a/src/common/CSV.cpp
+++ b/src/common/CSV.cpp
@@ -184,7 +184,7 @@ bool CSV::read_csv(const std::string &filename, bool contains_header) {
 
 void CSV::set_no_value_string(const std::string &str) { no_value_str_ = str; }
 
-int CSV::rows() { return table_.size(); }
+size_t CSV::rows() { return table_.size(); }
 
 double CSV::at(int row, const std::string &header) {
     const int column = column_headers_.at(header);

--- a/src/plugins/autonomy/RLConsensus/RLConsensus.cpp
+++ b/src/plugins/autonomy/RLConsensus/RLConsensus.cpp
@@ -53,16 +53,12 @@ REGISTER_PLUGIN(scrimmage::Autonomy, scrimmage::autonomy::RLConsensus, RLConsens
 namespace scrimmage {
 namespace autonomy {
 
-void RLConsensus::init(std::map<std::string, std::string> &params) {
-    RLSimple::init(params);
-}
-
 void RLConsensus::set_environment() {
     RLSimple::set_environment();
     reward_range = std::make_pair(0, 1 / parent_->mp()->tend());
 }
 
-std::pair<bool, double> RLConsensus::calc_reward(double /*t*/, double /*dt*/) {
+std::pair<bool, double> RLConsensus::calc_reward() {
     const bool done = false;
     const double x = state_->pos()(0);
     auto dist = [&](auto &kv) {return std::abs(kv.second.state()->pos()(0) - x);};

--- a/src/plugins/autonomy/RLSimple/RLSimple.cpp
+++ b/src/plugins/autonomy/RLSimple/RLSimple.cpp
@@ -30,6 +30,7 @@
  *
  */
 
+#include <scrimmage/common/Time.h>
 #include <scrimmage/math/State.h>
 #include <scrimmage/parse/ParseUtils.h>
 #include <scrimmage/plugin_manager/RegisterPlugin.h>
@@ -41,7 +42,7 @@ REGISTER_PLUGIN(scrimmage::Autonomy, scrimmage::autonomy::RLSimple, RLSimple_plu
 namespace scrimmage {
 namespace autonomy {
 
-void RLSimple::init(std::map<std::string, std::string> &params) {
+void RLSimple::init_helper(std::map<std::string, std::string> &params) {
     x_discrete_ = str2bool(params.at("x_discrete"));
     y_discrete_ = str2bool(params.at("y_discrete"));
     ctrl_y_ = str2bool(params.at("ctrl_y"));
@@ -58,8 +59,6 @@ void RLSimple::init(std::map<std::string, std::string> &params) {
     vars_.output(output_vel_z_idx, 0);
 
     radius_ = std::stod(params.at("radius"));
-
-    ScrimmageOpenAIAutonomy::init(params);
 }
 
 void RLSimple::set_environment() {
@@ -82,7 +81,7 @@ void RLSimple::set_environment() {
     }
 }
 
-std::pair<bool, double> RLSimple::calc_reward(double /*t*/, double /*dt*/) {
+std::pair<bool, double> RLSimple::calc_reward() {
     const bool done = false;
     const double x = state_->pos()(0);
     const bool within_radius = std::round(std::abs(x)) < radius_;
@@ -90,7 +89,7 @@ std::pair<bool, double> RLSimple::calc_reward(double /*t*/, double /*dt*/) {
     return {done, reward};
 }
 
-bool RLSimple::step_autonomy(double /*t*/, double /*dt*/) {
+bool RLSimple::step_helper() {
     // cppcheck-suppress variableScope
     int disc_idx = 0;
     // cppcheck-suppress variableScope

--- a/src/plugins/autonomy/ScrimmageOpenAIAutonomy/CMakeLists.txt
+++ b/src/plugins/autonomy/ScrimmageOpenAIAutonomy/CMakeLists.txt
@@ -9,14 +9,26 @@ SET (LIB_RELEASE 1)
 file(GLOB SRCS *.cpp)
 
 ADD_LIBRARY(${LIBRARY_NAME} SHARED 
-  ${SRCS}
+  ScrimmageOpenAIAutonomy.cpp
+  OpenAIObservations.cpp
+  OpenAIActions.cpp
+  OpenAIUtils.cpp
   )
 
+
+TARGET_INCLUDE_DIRECTORIES(${LIBRARY_NAME}
+  PUBLIC
+  ${PYTHON_INCLUDE_DIRS})
 
 TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
-  ${SCRIMMAGE_LIBS}
+  PUBLIC
+  scrimmage-core
+  scrimmage-python
   )
 
+target_compile_options(${LIBRARY_NAME}
+  PRIVATE -Wall -Wno-return-type-c-linkage -std=c++14 -fext-numeric-literals
+  )
 
 SET (_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})
 

--- a/src/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIActions.cpp
+++ b/src/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIActions.cpp
@@ -1,0 +1,169 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @date 31 July 2017
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+#include <scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIActions.h>
+#include <scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIUtils.h>
+#include <scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/ScrimmageOpenAIAutonomy.h>
+
+#include <iostream>
+
+namespace py = pybind11;
+
+namespace scrimmage {
+namespace autonomy {
+
+OpenAIActions::OpenAIActions() :
+    tuple_space_(get_gym_space("Tuple")),
+    box_space_(get_gym_space("Box")),
+    asarray_(py::module::import("numpy").attr("asarray")) {}
+
+std::vector<std::shared_ptr<ScrimmageOpenAIAutonomy>> &OpenAIActions::ext_ctrl_vec() {
+    return ext_ctrl_vec_;
+}
+
+void OpenAIActions::create_action_space(bool combine_actors) {
+
+    if (ext_ctrl_vec_.empty()) {
+        std::cout << "OpenAIActions::create_action_space called "
+            << "with 0 actors" << std::endl;
+    } else if (ext_ctrl_vec_.size() == 1 || combine_actors) {
+        py::list discrete_count;
+        py::list continuous_minima;
+        py::list continuous_maxima;
+
+        for (auto &a : ext_ctrl_vec_) {
+            a->set_environment();
+            to_discrete(a->action_space.discrete_count, discrete_count);
+            to_continuous(a->action_space.continuous_extrema, continuous_minima, continuous_maxima);
+        }
+
+        action_space =
+            create_space(discrete_count, continuous_minima, continuous_maxima);
+
+    } else {
+
+        py::list action_spaces;
+
+        for (auto &a : ext_ctrl_vec_) {
+            py::list discrete_count;
+            py::list continuous_minima;
+            py::list continuous_maxima;
+
+            a->set_environment();
+            to_discrete(a->action_space.discrete_count, discrete_count);
+            to_continuous(a->action_space.continuous_extrema, continuous_minima, continuous_maxima);
+
+            auto space =
+                create_space(discrete_count, continuous_minima, continuous_maxima);
+            action_spaces.append(space);
+        }
+
+        py::object tuple_space = get_gym_space("Tuple");
+        action_space = tuple_space(action_spaces);
+    }
+}
+
+void OpenAIActions::distribute_action(pybind11::object action, bool combine_actors) {
+    py::array_t<int> disc_actions;
+    py::array_t<double> cont_actions;
+    int* disc_action_data = nullptr;
+    double* cont_action_data = nullptr;
+
+    auto update_action_lists = [&](py::object space, py::object act) {
+        disc_actions = py::list();
+        cont_actions = py::list();
+        if (PyObject_IsInstance(space.ptr(), tuple_space_.ptr())) {
+            py::tuple action_list = act.cast<py::list>();
+            disc_actions = asarray_(action_list[0], py::str("int"));
+            cont_actions = asarray_(action_list[1], py::str("float"));
+            disc_action_data = static_cast<int*>(disc_actions.request().ptr);
+            cont_action_data = static_cast<double*>(cont_actions.request().ptr);
+        } else if (PyObject_IsInstance(space.ptr(), box_space_.ptr())) {
+            cont_actions = asarray_(act);
+            cont_action_data = static_cast<double*>(cont_actions.request().ptr);
+        } else {
+            disc_actions = asarray_(act);
+            disc_action_data = static_cast<int*>(disc_actions.request().ptr);
+        }
+    };
+
+    auto put_action = [&](int &idx, size_t from_sz, auto *from_data, auto &to_vec) {
+        if (to_vec.size() != from_sz) {
+            to_vec.resize(from_sz);
+        }
+        if (from_data == nullptr && from_sz > 0) {
+            std::cout << "Error: disc_action_data not set correctly" << std::endl;
+            return;
+        } else {
+            for (size_t i = 0; i < from_sz; i++) {
+                to_vec[i] = from_data[idx++];
+            }
+        }
+    };
+
+    auto put_actions = [&](auto a, int &disc_action_idx, int &cont_action_idx) {
+        put_action(disc_action_idx, a->action_space.discrete_count.size(),
+                   disc_action_data, a->action.discrete);
+        put_action(cont_action_idx, a->action_space.continuous_extrema.size(),
+                   cont_action_data, a->action.continuous);
+    };
+
+    if (ext_ctrl_vec_.size() == 1 || combine_actors) {
+
+        update_action_lists(action_space, action);
+
+        int disc_action_idx = 0;
+        int cont_action_idx = 0;
+        for (auto &a : ext_ctrl_vec_) {
+            put_actions(a, disc_action_idx, cont_action_idx);
+        }
+
+    } else {
+        py::list action_space_list = action_space.attr("spaces").cast<py::list>();
+        py::list action_list = action.cast<py::list>();
+        for (size_t i = 0; i < ext_ctrl_vec_.size(); i++) {
+            py::object indiv_action_space = action_space_list[i];
+            py::object indiv_action = action_list[i];
+            update_action_lists(indiv_action_space, indiv_action);
+            int disc_action_idx = 0;
+            int cont_action_idx = 0;
+            put_actions(ext_ctrl_vec_[i], disc_action_idx, cont_action_idx);
+        }
+    }
+}
+
+
+} // namespace autonomy
+} // namespace scrimmage

--- a/src/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIObservations.cpp
+++ b/src/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIObservations.cpp
@@ -1,0 +1,214 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @date 31 July 2017
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+
+#include <scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIUtils.h>
+#include <scrimmage/plugins/sensor/ScrimmageOpenAISensor/ScrimmageOpenAISensor.h>
+#include <scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIObservations.h>
+
+#include <boost/range/algorithm/transform.hpp>
+#include <boost/range/adaptor/filtered.hpp>
+#include <boost/range/adaptor/map.hpp>
+
+namespace py = pybind11;
+namespace br = boost::range;
+namespace ba = boost::adaptors;
+
+namespace scrimmage {
+namespace autonomy {
+
+OpenAIObservations::OpenAIObservations() :
+    tuple_space_(get_gym_space("Tuple")),
+    box_space_(get_gym_space("Box")) {}
+
+pybind11::object OpenAIObservations::update_observation(size_t num_entities) {
+
+    auto call_get_obs = [&](auto *data, uint32_t &beg_idx, auto sensor, int obs_size) {
+        uint32_t end_idx = beg_idx + obs_size;
+        if (end_idx != beg_idx) {
+            sensor->get_observation(data, beg_idx, end_idx);
+            beg_idx = end_idx;
+        }
+    };
+
+    auto init_arrays = [&](py::object obs_space, py::object obs) {
+        py::array_t<int> disc_obs;
+        py::array_t<double> cont_obs;
+        if (PyObject_IsInstance(obs_space.ptr(), tuple_space_.ptr())) {
+            py::list obs_list = obs.cast<py::list>();
+            disc_obs = obs_list[0].cast<py::array_t<int>>();
+            cont_obs = obs_list[1].cast<py::array_t<double>>();
+        } else if (PyObject_IsInstance(obs_space.ptr(), box_space_.ptr())) {
+            cont_obs = obs.cast<py::array_t<double>>();
+        } else {
+            disc_obs = obs.cast<py::array_t<int>>();
+        }
+
+        return std::make_tuple(disc_obs, cont_obs);
+    };
+
+    py::array_t<int> disc_obs;
+    py::array_t<double> cont_obs;
+    if (num_entities == 1 || combine_actors_) {
+
+        std::tie(disc_obs, cont_obs) = init_arrays(observation_space, observation);
+        uint32_t disc_beg_idx = 0;
+        uint32_t cont_beg_idx = 0;
+        int* r_disc = static_cast<int *>(disc_obs.request().ptr);
+        double* r_cont = static_cast<double *>(cont_obs.request().ptr);
+
+        bool done = false;
+        for (auto &v : ext_sensor_vec_) {
+            if (done) break;
+            for (auto &s : v) {
+                auto obs_space = s->observation_space;
+                call_get_obs(r_disc, disc_beg_idx, s, obs_space.discrete_count.size());
+                call_get_obs(r_cont, cont_beg_idx, s, obs_space.continuous_extrema.size());
+
+                if (num_entities > 1 && global_sensor_) {
+                    done = true;
+                    break;
+                }
+            }
+        }
+
+    } else {
+        py::list observation_space_list =
+            observation_space.attr("spaces").cast<py::list>();
+        py::list observation_list = observation.cast<py::list>();
+
+        for (size_t i = 0; i < ext_sensor_vec_.size(); i++) {
+            py::object indiv_space = observation_space_list[i];
+            py::object indiv_obs = observation_list[i];
+            std::tie(disc_obs, cont_obs) = init_arrays(indiv_space, indiv_obs);
+            uint32_t disc_beg_idx = 0;
+            uint32_t cont_beg_idx = 0;
+            int* r_disc = static_cast<int *>(disc_obs.request().ptr);
+            double* r_cont = static_cast<double *>(cont_obs.request().ptr);
+
+            for (auto &s : ext_sensor_vec_[i]) {
+                auto obs_space = s->observation_space;
+                call_get_obs(r_disc, disc_beg_idx, s, obs_space.discrete_count.size());
+                call_get_obs(r_cont, cont_beg_idx, s, obs_space.continuous_extrema.size());
+            }
+        }
+    }
+
+    return observation;
+}
+
+void OpenAIObservations::create_observation_space(size_t num_entities) {
+
+    auto create_obs = [&](py::list &discrete_count, py::list &continuous_maxima) -> py::object {
+
+        int len_discrete = py::len(discrete_count);
+        int len_continuous = py::len(continuous_maxima);
+
+        py::array_t<int> discrete_array(len_discrete);
+        py::array_t<double> continuous_array(len_continuous);
+
+        if (len_discrete > 0 && len_continuous > 0) {
+            py::list obs;
+            obs.append(discrete_array);
+            obs.append(continuous_array);
+            return obs;
+        } else if (len_continuous > 0) {
+            return continuous_array;
+        } else {
+            return discrete_array;
+        }
+    };
+
+    if (num_entities == 1 || combine_actors_) {
+        py::list discrete_count;
+        py::list continuous_minima;
+        py::list continuous_maxima;
+
+        bool done = false;
+        for (auto &v : ext_sensor_vec_) {
+            if (done) break;
+            for (auto &s : v) {
+                s->set_observation_space();
+                to_discrete(s->observation_space.discrete_count, discrete_count);
+                to_continuous(s->observation_space.continuous_extrema, continuous_minima, continuous_maxima);
+
+                if (num_entities > 1 && global_sensor_) {
+                    done = true;
+                    break;
+                }
+            }
+        }
+
+        observation_space =
+            create_space(discrete_count, continuous_minima, continuous_maxima);
+
+        observation = create_obs(discrete_count, continuous_maxima);
+
+    } else {
+
+        py::list observation_spaces;
+        py::list obs;
+
+        for (auto &v : ext_sensor_vec_) {
+            for (auto &s : v) {
+                py::list discrete_count;
+                py::list continuous_minima;
+                py::list continuous_maxima;
+
+                s->set_observation_space();
+                to_discrete(s->observation_space.discrete_count, discrete_count);
+                to_continuous(s->observation_space.continuous_extrema, continuous_minima, continuous_maxima);
+
+                auto space =
+                    create_space(discrete_count, continuous_minima, continuous_maxima);
+                observation_spaces.append(space);
+                obs.append(create_obs(discrete_count, continuous_maxima));
+            }
+        }
+
+        py::object tuple_space = get_gym_space("Tuple");
+        observation_space = tuple_space(observation_spaces);
+        observation = obs;
+    }
+}
+
+void OpenAIObservations::add_sensors(const std::unordered_map<std::string, SensorPtr> &sensors) {
+    std::vector<std::shared_ptr<sensor::ScrimmageOpenAISensor>> vec;
+    auto cast = [&](auto &p) {return std::dynamic_pointer_cast<sensor::ScrimmageOpenAISensor>(p);};
+    auto good_ptr = [&](auto &p) {return cast(p) != nullptr;};
+    br::transform(sensors | ba::map_values | ba::filtered(good_ptr), std::back_inserter(vec), cast);
+    ext_sensor_vec_.push_back(vec);
+}
+} // namespace autonomy
+} // namespace scrimmage

--- a/src/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIUtils.cpp
+++ b/src/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIUtils.cpp
@@ -1,0 +1,103 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @date 31 July 2017
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#include <scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/OpenAIUtils.h>
+
+#include <pybind11/numpy.h>
+
+namespace py = pybind11;
+
+namespace scrimmage {
+namespace autonomy {
+
+void to_continuous(std::vector<std::pair<double, double>> &p,
+                   pybind11::list &minima,
+                   pybind11::list &maxima) {
+    for (auto &value : p) {
+        py::list min_max;
+        minima.append(value.first);
+        maxima.append(value.second);
+    }
+}
+
+void to_discrete(std::vector<double> &p, py::list &maxima) {
+    for (auto &value : p) {
+        maxima.append(value);
+    }
+}
+
+pybind11::object create_space(
+        pybind11::list discrete_count,
+        pybind11::list continuous_minima,
+        pybind11::list continuous_maxima) {
+
+    py::module np = py::module::import("numpy");
+    py::object np_array = np.attr("array");
+    py::object np_float32 = np.attr("float32");
+
+    py::object gym_discrete_space = get_gym_space("Discrete");
+    py::object gym_multidiscrete_space = get_gym_space("MultiDiscrete");
+    py::object gym_box_space = get_gym_space("Box");
+    py::object gym_tuple_space = get_gym_space("Tuple");
+
+    py::object discrete_space = py::len(discrete_count) == 1 ?
+        gym_discrete_space(discrete_count[0]) :
+        gym_multidiscrete_space(discrete_count);
+
+    py::object continuous_space = gym_box_space(
+        np_array(continuous_minima),
+        np_array(continuous_maxima),
+        py::none(),
+        np_float32);
+
+    int len_discrete = py::len(discrete_count);
+    int len_continuous = py::len(continuous_minima);
+    if (len_discrete != 0 && len_continuous != 0) {
+        py::list spaces;
+        spaces.append(discrete_space);
+        spaces.append(continuous_space);
+        return gym_tuple_space(spaces);
+    } else if (len_discrete != 0) {
+        return discrete_space;
+    } else if (len_continuous != 0) {
+        return continuous_space;
+    } else {
+        // TODO: error handling
+        return pybind11::object();
+    }
+}
+
+pybind11::object get_gym_space(const std::string &type) {
+    return pybind11::module::import("gym").attr("spaces").attr(type.c_str());
+}
+} // namespace autonomy
+} // namespace scrimmage

--- a/src/plugins/autonomy/ScrimmageOpenAIAutonomy/ScrimmageOpenAIAutonomy.cpp
+++ b/src/plugins/autonomy/ScrimmageOpenAIAutonomy/ScrimmageOpenAIAutonomy.cpp
@@ -30,11 +30,15 @@
  *
  */
 
+#include <pybind11/pybind11.h>
+
+#include <scrimmage/common/Time.h>
 #include <scrimmage/entity/Entity.h>
 #include <scrimmage/parse/ParseUtils.h>
 #include <scrimmage/plugins/autonomy/ScrimmageOpenAIAutonomy/ScrimmageOpenAIAutonomy.h>
 #include <scrimmage/plugin_manager/RegisterPlugin.h>
 #include <scrimmage/pubsub/Message.h>
+#include <scrimmage/pubsub/Publisher.h>
 #include <scrimmage/math/State.h>
 #include <scrimmage/sensor/Sensor.h>
 
@@ -47,6 +51,7 @@
 #include <thread> // NOLINT
 
 namespace sp = scrimmage_proto;
+namespace py = pybind11;
 
 REGISTER_PLUGIN(scrimmage::Autonomy, scrimmage::autonomy::ScrimmageOpenAIAutonomy, ScrimmageOpenAIAutonomy_plugin)
 
@@ -55,18 +60,74 @@ namespace autonomy {
 
 ScrimmageOpenAIAutonomy::ScrimmageOpenAIAutonomy() :
     reward_range(-std::numeric_limits<double>::infinity(),
-                 std::numeric_limits<double>::infinity()) {}
+                 std::numeric_limits<double>::infinity()),
+    nonlearning_mode_(false) {}
 
-void ScrimmageOpenAIAutonomy::init(std::map<std::string, std::string> &/*params*/) {
-    print_err_on_exit = false;
-    return;
+void ScrimmageOpenAIAutonomy::init(std::map<std::string, std::string> &params) {
+    init_helper(params);
+
+    nonlearning_mode_ = get("nonlearning_mode_openai_plugin", params, true);
+
+    if (nonlearning_mode_) {
+        // get the actor func
+        const std::string module = params.at("module");
+        actor_func_ = py::module::import(module.c_str());
+
+        std::vector<std::string> tokens;
+        split(tokens, params.at("actor_func"), ".");
+        for (std::string s : tokens) {
+            actor_func_ = actor_func_.attr(py::str(s));
+        }
+
+        // there is only 1 entity in this case so it would make no sense
+        // to combine actors
+        const size_t num_entities = 1;
+
+        auto p = std::dynamic_pointer_cast<ScrimmageOpenAIAutonomy>(shared_from_this());
+        actions_.ext_ctrl_vec().push_back(p);
+        actions_.create_action_space(false);
+
+        observations_.set_combine_actors(false);
+        observations_.set_global_sensor(false);
+
+        observations_.add_sensors(parent_->sensors());
+
+        observations_.create_observation_space(num_entities);
+    }
+
+    pub_reward_ = advertise("GlobalNetwork", "reward");
 }
 
 bool ScrimmageOpenAIAutonomy::step_autonomy(double /*t*/, double /*dt*/) {
-    return false;
+    if (nonlearning_mode_) {
+        const size_t num_entities = 1;
+        observations_.update_observation(num_entities);
+        py::object temp_action = actor_func_(observations_.observation);
+
+        bool combine_actors = false;
+        actions_.distribute_action(temp_action, combine_actors);
+
+        if (first_step_) {
+            // there is no reward on the first step
+            first_step_ = false;
+        } else {
+            bool done;
+            double reward;
+            std::tie(done, reward) = calc_reward();
+            if (done) return false;
+            if (reward != 0) {
+                auto msg = std::make_shared<Message<std::pair<size_t, double>>>();
+                msg->data.first = parent_->id().id();
+                msg->data.second = reward;
+                pub_reward_->publish(msg);
+            }
+        }
+    }
+
+    return step_helper();
 }
 
-std::pair<bool, double> ScrimmageOpenAIAutonomy::calc_reward(double /*t*/, double /*dt*/) {
+std::pair<bool, double> ScrimmageOpenAIAutonomy::calc_reward() {
     return {false, 0.0};
 }
 

--- a/src/plugins/autonomy/TrajectoryRecordPlayback/TrajectoryRecordPlayback.cpp
+++ b/src/plugins/autonomy/TrajectoryRecordPlayback/TrajectoryRecordPlayback.cpp
@@ -90,7 +90,7 @@ void TrajectoryRecordPlayback::init(std::map<std::string,
                  << endl;
         }
 
-        for (int r = 0; r < csv_.rows(); r++) {
+        for (size_t r = 0; r < csv_.rows(); r++) {
             scrimmage::State desired_state;
             desired_state.pos() << csv_.at(r, "x_d"),
                 csv_.at(r, "y_d"),

--- a/src/plugins/metrics/OpenAIRewards/CMakeLists.txt
+++ b/src/plugins/metrics/OpenAIRewards/CMakeLists.txt
@@ -1,7 +1,7 @@
 #--------------------------------------------------------
 # Library Creation
 #--------------------------------------------------------
-set(LIBRARY_NAME ScrimmageOpenAISensor_plugin)
+set(LIBRARY_NAME OpenAIRewards_plugin)
 set(LIB_MAJOR 0)
 set(LIB_MINOR 0)
 set(LIB_RELEASE 1)
@@ -12,6 +12,14 @@ add_library(${LIBRARY_NAME} SHARED
   ${SRCS}
 )
 
+target_compile_options(${LIBRARY_NAME}
+  PRIVATE -Wall -Wno-return-type-c-linkage -std=c++14
+)
+
+target_link_libraries(${LIBRARY_NAME}
+  scrimmage-core
+)
+
 set(_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})
 
 set_target_properties(${LIBRARY_NAME} PROPERTIES
@@ -20,15 +28,11 @@ set_target_properties(${LIBRARY_NAME} PROPERTIES
   LIBRARY_OUTPUT_DIRECTORY ${PROJECT_PLUGIN_LIBS_DIR}
 )
 
-TARGET_INCLUDE_DIRECTORIES(${LIBRARY_NAME}
+target_include_directories(${LIBRARY_NAME}
   PUBLIC
-  ${PYTHON_INCLUDE_DIRS})
-
-TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
-  PUBLIC
-  scrimmage-core
-  scrimmage-python
-  )
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${PROJECT_INC_DIR}>
+)
 
 install(TARGETS ${LIBRARY_NAME}
   # IMPORTANT: Add the library to the "export-set"

--- a/src/plugins/metrics/OpenAIRewards/OpenAIRewards.cpp
+++ b/src/plugins/metrics/OpenAIRewards/OpenAIRewards.cpp
@@ -1,0 +1,106 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @date 31 July 2017
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#include <scrimmage/plugins/metrics/OpenAIRewards/OpenAIRewards.h>
+
+#include <scrimmage/common/CSV.h>
+#include <scrimmage/plugin_manager/RegisterPlugin.h>
+#include <scrimmage/entity/Entity.h>
+#include <scrimmage/math/State.h>
+#include <scrimmage/parse/ParseUtils.h>
+#include <scrimmage/parse/MissionParse.h>
+#include <scrimmage/common/Utilities.h>
+#include <scrimmage/metrics/Metrics.h>
+
+#include <scrimmage/pubsub/Message.h>
+#include <scrimmage/pubsub/Subscriber.h>
+#include <scrimmage/msgs/Collision.pb.h>
+#include <scrimmage/msgs/Event.pb.h>
+
+#include <iostream>
+#include <limits>
+
+using std::cout;
+using std::endl;
+
+namespace sc = scrimmage;
+namespace sm = scrimmage_msgs;
+
+REGISTER_PLUGIN(scrimmage::Metrics,
+                scrimmage::metrics::OpenAIRewards,
+                OpenAIRewards_plugin)
+
+namespace scrimmage {
+namespace metrics {
+
+OpenAIRewards::OpenAIRewards() : Metrics() {
+    print_team_summary_ = false;
+}
+
+void OpenAIRewards::init(std::map<std::string, std::string> &/*params*/) {
+    auto cb = [&](auto msg) {
+        size_t id;
+        double reward;
+        std::tie(id, reward) = msg->data;
+        auto it = rewards_.find(id);
+        if (it == rewards_.end()) {
+            rewards_[id] = reward;
+        } else {
+            it->second += reward;
+        }
+        print_team_summary_ = true;
+    };
+    subscribe<std::pair<size_t, double>>("GlobalNetwork", "reward", cb);
+}
+
+void OpenAIRewards::print_team_summaries() {
+    for (auto &kv : rewards_) {
+        std::cout << "Reward for id " << kv.first << " = " << kv.second << std::endl;
+    }
+}
+
+void OpenAIRewards::calc_team_scores() {
+    CSV csv;
+    std::string filename = parent_->mp()->log_dir() + "/rewards.csv";
+
+    if (!csv.open_output(filename)) {
+       std::cout << "Couldn't create output file" << endl;
+    }
+
+    csv.set_column_headers("id, reward");
+    for (auto &kv : rewards_) {
+        csv.append(CSV::Pairs{{"id", kv.first}, {"reward", kv.second}});
+    }
+    csv.close_output();
+}
+} // namespace metrics
+} // namespace scrimmage

--- a/src/plugins/sensor/RLSimpleSensor/RLSimpleSensor.cpp
+++ b/src/plugins/sensor/RLSimpleSensor/RLSimpleSensor.cpp
@@ -32,6 +32,7 @@
 
 #include <scrimmage/plugins/sensor/RLSimpleSensor/RLSimpleSensor.h>
 
+#include <scrimmage/common/Time.h>
 #include <scrimmage/entity/Entity.h>
 #include <scrimmage/math/State.h>
 #include <scrimmage/plugin_manager/RegisterPlugin.h>
@@ -43,10 +44,12 @@ namespace sensor {
 
 void RLSimpleSensor::get_observation(double *data, uint32_t beg_idx, uint32_t /*end_idx*/) {
     data[beg_idx] = parent_->state()->pos()(0);
+    data[beg_idx + 1] = time_->t();
 }
 
 void RLSimpleSensor::set_observation_space() {
     const double inf = std::numeric_limits<double>::infinity();
+    observation_space.continuous_extrema.push_back(std::make_pair(-inf, inf));
     observation_space.continuous_extrema.push_back(std::make_pair(-inf, inf));
 }
 

--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -1422,19 +1422,24 @@ bool SimControl::output_summary() {
     std::map<int, std::map<std::string, double>> team_metrics;
     std::list<std::string> headers;
 
+    bool metrics_empty = true;
+
     // Loop through each of the metrics plugins.
     for (auto metrics : metrics_) {
-        cout << sc::generate_chars("=", 80) << endl;
-        cout << metrics->name() << endl;
-        cout << sc::generate_chars("=", 80) << endl;
-        metrics->calc_team_scores();
-        metrics->print_team_summaries();
+        if (metrics->get_print_team_summary()) {
+            cout << sc::generate_chars("=", 80) << endl;
+            cout << metrics->name() << endl;
+            cout << sc::generate_chars("=", 80) << endl;
+            metrics->calc_team_scores();
+            metrics->print_team_summaries();
+        }
 
         // Add all elements from individual metrics plugin to overall
         // metrics data structure
         for (auto const &team_str_double : metrics->team_metrics()) {
             team_metrics[team_str_double.first].insert(team_str_double.second.begin(),
                                                        team_str_double.second.end());
+            metrics_empty = false;
         }
 
         // Calculate aggregated team scores:
@@ -1491,13 +1496,15 @@ bool SimControl::output_summary() {
     summary_file.close();
 
     // Print Overall Scores
-    cout << sc::generate_chars("=", 80) << endl;
-    cout << "Overall Scores" << endl;
-    cout << sc::generate_chars("=", 80) << endl;
-    for (auto const &team_score : team_scores) {
-        cout << "Team ID: " << team_score.first << endl;
-        cout << "Score: " << team_score.second << endl;
-        cout << sc::generate_chars("-", 80) << endl;
+    if (!metrics_empty) {
+        cout << sc::generate_chars("=", 80) << endl;
+        cout << "Overall Scores" << endl;
+        cout << sc::generate_chars("=", 80) << endl;
+        for (auto const &team_score : team_scores) {
+            cout << "Team ID: " << team_score.first << endl;
+            cout << "Score: " << team_score.second << endl;
+            cout << sc::generate_chars("-", 80) << endl;
+        }
     }
 
     return true;

--- a/src/simcontrol/SimUtils.cpp
+++ b/src/simcontrol/SimUtils.cpp
@@ -216,7 +216,7 @@ std::function<void(int)> shutdown_handler;
 void signal_handler(int signal) { shutdown_handler(signal); }
 } // namespace
 
-boost::optional<std::string> run_test(std::string mission) {
+boost::optional<std::string> run_test(std::string mission, bool init_python) {
 
     auto found_mission = FileSearch().find_mission(mission);
     if (!found_mission) {
@@ -248,7 +248,7 @@ boost::optional<std::string> run_test(std::string mission) {
 
         auto log = preprocess_scrimmage(mp, simcontrol);
 #if ENABLE_PYTHON_BINDINGS == 1
-        Py_Initialize();
+        if (init_python) Py_Initialize();
 #endif
         if (log == nullptr) {
             return boost::none;
@@ -259,7 +259,7 @@ boost::optional<std::string> run_test(std::string mission) {
         auto out = postprocess_scrimmage(mp, simcontrol, log);
 
 #if ENABLE_PYTHON_BINDINGS == 1
-    Py_Finalize();
+        if (init_python) Py_Finalize();
 #endif
         return out;
     }

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,4 +1,23 @@
 FILE(GLOB test_files test_*.cpp test_*.cc)
+set(test_files
+    test_algorithms.cpp
+    test_angles.cpp
+    test_collisions.cpp
+    test_delayed_task.cpp
+    test_exponential_filter.cpp
+    test_find_mission.cpp
+    test_id.cpp
+    test_params.cpp
+    test_quaternion.cpp
+    test_rtree.cpp
+    test_simple.cpp
+    test_state.cpp
+    test_utilities.cpp)
+
+if (NOT ENABLE_PYTHON_BINDINGS)
+    LIST(REMOVE_ITEM test_files "test_openai.py")
+endif()
+
 foreach(test_file ${test_files})
   get_filename_component(test_name ${test_file} NAME_WE)
   add_executable(${test_name} ${test_file})

--- a/test/test_openai.cpp
+++ b/test/test_openai.cpp
@@ -1,0 +1,90 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @date 31 July 2017
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#include <gtest/gtest.h>
+
+#include <pybind11/pybind11.h>
+#include <pybind11/embed.h>
+
+#include <scrimmage/common/CSV.h>
+#include <scrimmage/simcontrol/SimUtils.h>
+
+#include <boost/optional.hpp>
+
+namespace sc = scrimmage;
+namespace py = pybind11;
+using namespace pybind11::literals; // NOLINT
+
+void runner(bool x_discrete, bool ctrl_y, bool y_discrete, size_t num_actors,
+            const std::string &actor_func,
+            const std::map<int, double> &expected_rewards) {
+
+    py::object test_open_ai_module = py::module::import("test_openai");
+    py::object write_temp_mission = test_open_ai_module.attr("_write_temp_mission");
+
+    write_temp_mission(
+        "x_discrete"_a = x_discrete, "ctrl_y"_a = ctrl_y, "y_discrete"_a = y_discrete,
+        "num_actors"_a = num_actors, "end"_a = 1000,
+        "actor_func"_a = actor_func);
+
+    const std::string mission = ".rlsimple";
+    auto log_dir = sc::run_test(mission, false);
+
+    bool success = log_dir ? true : false;
+    EXPECT_TRUE(success);
+    if (!log_dir) return;
+
+    sc::CSV csv;
+    bool rewards_found = csv.read_csv(*log_dir + "/rewards.csv");
+    EXPECT_TRUE(rewards_found);
+    if (!rewards_found) return;
+
+    for (size_t row = 0; row < csv.rows(); row++) {
+        int id = csv.at(row, "id");
+        double actual_reward = csv.at(row, "reward");
+        EXPECT_EQ(actual_reward, expected_rewards.at(id));
+    }
+}
+
+TEST(TestOpenAI, one_dim_discrete) {
+    Py_Initialize();
+    runner(true, false, true, 1, "get_action_test_one_dim_discrete", {{1, 4}});
+    runner(true, true, true, 1, "get_action_test_two_dim_discrete", {{1, 4}});
+    runner(false, false, true, 1, "get_action_test_one_dim_continuous", {{1, 4}});
+    runner(false, true, false, 1, "get_action_test_two_dim_continuous", {{1, 4}});
+    runner(false, true, true, 1, "get_action_test_two_dim_tuple", {{1, 4}});
+
+    // when there are multiple vehicles we need to specify an action
+    // that is specific to an entity
+    runner(true, false, true, 2, "get_action_test_one_dim_discrete", {{1, 4}, {2, 4}});
+    Py_Finalize();
+}

--- a/test/test_openai.py
+++ b/test/test_openai.py
@@ -29,14 +29,12 @@ This file is part of SCRIMMAGE.
 @section DESCRIPTION
 A Long description goes here.
 """
-
 import xml.etree.ElementTree as ET
 import copy
-import signal
 
 import numpy as np
 import gym
-import scrimmage
+import scrimmage.utils
 
 MISSION_FILE = 'rlsimple.xml'
 TEMP_MISSION_FILE = '.rlsimple.xml'
@@ -48,7 +46,7 @@ def _run_test(version, combine_actors, global_sensor, get_action, timestep=-1):
     except gym.error.Error:
         gym.envs.register(
             id=version,
-            entry_point='scrimmage:ScrimmageOpenAIEnv',
+            entry_point='scrimmage.bindings:ScrimmageOpenAIEnv',
             max_episode_steps=1e9,
             reward_threshold=1e9,
             kwargs={"enable_gui": False,
@@ -62,10 +60,11 @@ def _run_test(version, combine_actors, global_sensor, get_action, timestep=-1):
     # the observation is the state of the aircraft
     obs = []
 
-    obs.append(np.copy(env.reset()))
+    temp_obs = np.copy(env.reset())
+    obs.append(temp_obs)
     total_reward = 0
     for i in range(1000):
-        action = get_action(i)
+        action = get_action(temp_obs)
         temp_obs, reward, done = env.step(action)[:3]
         obs.append(np.copy(temp_obs))
         try:
@@ -82,8 +81,9 @@ def _run_test(version, combine_actors, global_sensor, get_action, timestep=-1):
     return env, obs, total_reward
 
 
-def _write_temp_mission(x_discrete, ctrl_y, y_discrete, num_actors, end):
-    tree = ET.parse(scrimmage.find_mission(MISSION_FILE))
+def _write_temp_mission(x_discrete, ctrl_y, y_discrete, num_actors, end,
+                        actor_func=''):
+    tree = ET.parse(scrimmage.utils.find_mission(MISSION_FILE))
     root = tree.getroot()
 
     run_node = root.find("run")
@@ -94,6 +94,7 @@ def _write_temp_mission(x_discrete, ctrl_y, y_discrete, num_actors, end):
     autonomy_node.attrib['x_discrete'] = str(x_discrete)
     autonomy_node.attrib['y_discrete'] = str(y_discrete)
     autonomy_node.attrib['ctrl_y'] = str(ctrl_y)
+    autonomy_node.attrib['actor_func'] = actor_func
 
     if num_actors == 2:
         entity_node2 = copy.deepcopy(root.find('entity'))
@@ -102,21 +103,52 @@ def _write_temp_mission(x_discrete, ctrl_y, y_discrete, num_actors, end):
     tree.write(TEMP_MISSION_FILE)
 
 
+def get_action_test_one_dim_discrete(i):
+    return 1 if i[1] < 100 else 0
+
+
+def get_action_test_two_dim_discrete(i):
+    return np.array([1, 1] if i[1] < 100 else [0, 0], dtype=int)
+
+
+def get_action_test_one_dim_continuous(i):
+    return 1.0 if i[1] < 100 else -1.0
+
+
+def get_action_test_two_dim_continuous(i):
+    return np.array([1.0, 1.0] if i[1] < 100 else [-1.0, -1.0], dtype=float)
+
+
+def get_action_test_two_dim_tuple(i):
+    return np.array([[1], [1.0]] if i[1] < 100 else [[0], [-1.0]])
+
+
+def get_action_two_combined_veh_dim_discrete(i):
+    return [1, 0] if i[1] < 100 else [0, 1]
+
+
+def get_action_test_two_not_combined_veh_dim_discrete(i):
+    return [[1], [0]] if i[0][1] < 100 else [[0], [1]]
+
+
+def get_action_test_two_combined_veh_dim_discrete_global_sensor(i):
+    return [1, 0] if i[1] < 100 else [0, 1]
+
+
 def test_one_dim_discrete():
     """A single agent along the x-axis."""
-    def _get_action(i):
-        return 1 if i < 100 else 0
-
     VERSION = 'scrimmage-v0'
     _write_temp_mission(x_discrete=True, ctrl_y=False, y_discrete=True,
                         num_actors=1, end=1000)
     combine_actors = False
     global_sensor = False
     env, obs, total_reward = \
-        _run_test(VERSION, combine_actors, global_sensor, _get_action)
+        _run_test(VERSION, combine_actors, global_sensor,
+                  get_action_test_one_dim_discrete)
 
-    assert len(obs[0]) == 1
+    assert len(obs[0]) == 2
     assert obs[0][0] == 0
+    assert obs[0][1] == 0
     assert isinstance(env.action_space, gym.spaces.Discrete)
     assert isinstance(env.observation_space, gym.spaces.Box)
     assert env.action_space.n == 2
@@ -125,19 +157,18 @@ def test_one_dim_discrete():
 
 def test_two_dim_discrete():
     """A single agent along the x and y-axis."""
-    def _get_action(i):
-        return np.array([1, 1] if i < 100 else [0, 0], dtype=int)
-
     VERSION = 'scrimmage-v1'
     _write_temp_mission(x_discrete=True, ctrl_y=True, y_discrete=True,
                         num_actors=1, end=1000)
     combine_actors = False
     global_sensor = False
     env, obs, total_reward = \
-        _run_test(VERSION, combine_actors, global_sensor, _get_action)
+        _run_test(VERSION, combine_actors, global_sensor,
+                  get_action_test_two_dim_discrete)
 
-    assert len(obs[0]) == 1
-    assert obs[0] == 0
+    assert len(obs[0]) == 2
+    assert obs[0][0] == 0
+    assert obs[0][1] == 0
     assert isinstance(env.action_space, gym.spaces.MultiDiscrete)
     assert isinstance(env.observation_space, gym.spaces.Box)
     assert np.array_equal(env.action_space.nvec, np.array([2, 2], dtype=int))
@@ -146,19 +177,18 @@ def test_two_dim_discrete():
 
 def test_two_dim_continuous():
     """A single agent along the x and y-axis with continuous input."""
-    def _get_action(i):
-        return np.array([1.0, 1.0] if i < 100 else [-1.0, -1.0], dtype=float)
-
     VERSION = 'scrimmage-v2'
     _write_temp_mission(x_discrete=False, ctrl_y=True, y_discrete=False,
                         num_actors=1, end=1000)
     combine_actors = False
     global_sensor = False
     env, obs, total_reward = \
-        _run_test(VERSION, combine_actors, global_sensor, _get_action)
+        _run_test(VERSION, combine_actors, global_sensor,
+                  get_action_test_two_dim_continuous)
 
-    assert len(obs[0]) == 1
-    assert obs[0] == 0
+    assert len(obs[0]) == 2
+    assert obs[0][0] == 0
+    assert obs[0][1] == 0
     assert isinstance(env.action_space, gym.spaces.Box)
     assert isinstance(env.observation_space, gym.spaces.Box)
     assert total_reward == 4
@@ -166,19 +196,18 @@ def test_two_dim_continuous():
 
 def test_two_dim_tuple():
     """Single agent with discrete and continuous input."""
-    def _get_action(i):
-        return np.array([[1], [1.0]] if i < 100 else [[0], [-1.0]])
-
     VERSION = 'scrimmage-v3'
     _write_temp_mission(x_discrete=False, ctrl_y=True, y_discrete=True,
                         num_actors=1, end=1000)
     combine_actors = False
     global_sensor = False
     env, obs, total_reward = \
-        _run_test(VERSION, combine_actors, global_sensor, _get_action)
+        _run_test(VERSION, combine_actors, global_sensor,
+                  get_action_test_two_dim_tuple)
 
-    assert len(obs[0]) == 1
-    assert obs[0] == 0
+    assert len(obs[0]) == 2
+    assert obs[0][0] == 0
+    assert obs[0][1] == 0
     assert isinstance(env.action_space, gym.spaces.Tuple)
     assert isinstance(env.observation_space, gym.spaces.Box)
     assert total_reward == 4
@@ -186,19 +215,18 @@ def test_two_dim_tuple():
 
 def test_one_dim_continuous():
     """A single agent along the x-axis with continuous input."""
-    def _get_action(i):
-        return 1.0 if i < 100 else -1.0
-
     VERSION = 'scrimmage-v4'
     _write_temp_mission(x_discrete=False, ctrl_y=False, y_discrete=False,
                         num_actors=1, end=1000)
     combine_actors = False
     global_sensor = False
     env, obs, total_reward = \
-        _run_test(VERSION, combine_actors, global_sensor, _get_action)
+        _run_test(VERSION, combine_actors, global_sensor,
+                  get_action_test_one_dim_continuous)
 
-    assert len(obs[0]) == 1
-    assert obs[0] == 0
+    assert len(obs[0]) == 2
+    assert obs[0][0] == 0
+    assert obs[0][1] == 0
     assert isinstance(env.action_space, gym.spaces.Box)
     assert isinstance(env.observation_space, gym.spaces.Box)
     assert total_reward == 4
@@ -206,19 +234,17 @@ def test_one_dim_continuous():
 
 def test_two_combined_veh_dim_discrete():
     """Two agents, each with one discrete input, treated as a single agent."""
-    def _get_action(i):
-        return [1, 0] if i < 100 else [0, 1]
-
     VERSION = 'scrimmage-v5'
     _write_temp_mission(x_discrete=True, ctrl_y=False, y_discrete=False,
                         num_actors=2, end=1000)
     combine_actors = True
     global_sensor = False
     env, obs, total_reward = \
-        _run_test(VERSION, combine_actors, global_sensor, _get_action)
+        _run_test(VERSION, combine_actors, global_sensor,
+                  get_action_two_combined_veh_dim_discrete)
 
-    assert len(obs[0]) == 2
-    assert np.array_equal(obs[0], np.array([0., 0.]))
+    assert len(obs[0]) == 4
+    assert np.array_equal(obs[0], np.zeros(4))
     assert isinstance(env.action_space, gym.spaces.MultiDiscrete)
     assert isinstance(env.observation_space, gym.spaces.Box)
     assert total_reward == 8
@@ -226,20 +252,16 @@ def test_two_combined_veh_dim_discrete():
 
 def test_two_not_combined_veh_dim_discrete():
     """Two agents, each with discrete input, treated as separate agents."""
-    def _get_action(i):
-        return [[1], [0]] if i < 100 else [[0], [1]]
-
     VERSION = 'scrimmage-v6'
     _write_temp_mission(x_discrete=True, ctrl_y=False, y_discrete=False,
                         num_actors=2, end=1000)
     combine_actors = False
     global_sensor = False
     env, obs, total_reward = \
-        _run_test(VERSION, combine_actors, global_sensor, _get_action)
+        _run_test(VERSION, combine_actors, global_sensor,
+                  get_action_test_two_not_combined_veh_dim_discrete)
 
-    assert len(obs[0]) == 2
-    assert obs[0][0] == 0
-    assert obs[0][1] == 0
+    assert np.array_equal(obs[0], np.zeros((2, 2)))
     assert isinstance(env.action_space, gym.spaces.Tuple)
     assert isinstance(env.observation_space, gym.spaces.Tuple)
     assert total_reward == 8
@@ -251,19 +273,17 @@ def test_two_combined_veh_dim_discrete_global_sensor():
     global_sensor means that the sensor of the first agent will define the
     state.
     """
-    def _get_action(i):
-        return [1, 0] if i < 100 else [0, 1]
-
     VERSION = 'scrimmage-v7'
     _write_temp_mission(x_discrete=True, ctrl_y=False, y_discrete=False,
                         num_actors=2, end=1000)
     combine_actors = True
     global_sensor = True
     env, obs, total_reward = \
-        _run_test(VERSION, combine_actors, global_sensor, _get_action)
+        _run_test(VERSION, combine_actors, global_sensor,
+                  get_action_test_two_combined_veh_dim_discrete_global_sensor)
 
-    assert len(obs[0]) == 1
-    assert np.array_equal(obs[0], np.array([0.]))
+    assert len(obs[0]) == 2
+    assert np.array_equal(obs[0], np.zeros(2))
     assert isinstance(env.action_space, gym.spaces.MultiDiscrete)
     assert isinstance(env.observation_space, gym.spaces.Box)
     assert total_reward == 8
@@ -272,7 +292,7 @@ def test_two_combined_veh_dim_discrete_global_sensor():
 def test_sim_end():
     """Verify that scrimmage can close an environment."""
     def _get_action(i):
-        return 1 if i < 100 else 0
+        return 1 if i[1] < 100 else 0
 
     VERSION = 'scrimmage-v8'
     _write_temp_mission(x_discrete=True, ctrl_y=False, y_discrete=True,
@@ -286,7 +306,7 @@ def test_sim_end():
 def test_timestep():
     """Verify that scrimmage closes."""
     def _get_action(i):
-        return 1 if i < 100 else 0
+        return 1 if i[1] < 100 else 0
 
     VERSION = 'scrimmage-v9'
     _write_temp_mission(x_discrete=True, ctrl_y=False, y_discrete=True,
@@ -296,13 +316,13 @@ def test_timestep():
     env, obs, total_reward = \
         _run_test(VERSION, combine_actors, global_sensor, _get_action, 10)
 
-    assert len(obs[0]) == 1
+    assert len(obs[0]) == 2
     assert obs[0][0] == 0
     assert obs[1][0] == 10
     assert isinstance(env.action_space, gym.spaces.Discrete)
     assert isinstance(env.observation_space, gym.spaces.Box)
     assert env.action_space.n == 2
-    assert total_reward == 0
+    assert total_reward == 1
 
 if __name__ == '__main__':
     test_one_dim_discrete()


### PR DESCRIPTION
This changes the API so I added a changelog file so we can track these types of things. The main thing a user would have to do to update:

* change `init` to `init_helper`
* change `step_autonomy` to `step_helper`
* instead of `import scrimmage`, do `import scrimmage.utils` (or `import scrimmage.bindings`, `import scrimmage.proto_utils`)

The first two only apply for users who are inheriting from `ScrimmageOpenAIAutonomy`