### PR TITLE
Fix bug in UUV6DOF

### DIFF
--- a/src/plugins/motion/UUV6DOF/UUV6DOF.cpp
+++ b/src/plugins/motion/UUV6DOF/UUV6DOF.cpp
@@ -268,7 +268,7 @@ bool UUV6DOF::step(double time, double dt) {
 
     // Limit depth/height
     if (x_[Zw] >= surface_height_) {
-        x_[Zw] = surface_height_;
+        x_[Zw] = surface_height_ - std::numeric_limits<double>::epsilon();
         if (x_[Q] > 0) {
             x_[Q] *= 0.90;
             x_[Q_dot] *= 0.10;


### PR DESCRIPTION
There was in issue in UUV6DOF where we set a variable to exactly 0. In the motion model calculations this later caused NaNs, causing the entity to disappear. This is a simple change - in the case that the motion model put the UUV above the surface of the water, we had been setting it's height to the surface height. Now instead we set it to std::numeric_limits<double>::epsilon subtracted from the surface height, letting us not have an exact 0 in the case that surface_height_ is 0. 

From my test this fixed the NaN problems.