### PR TITLE
Drawing avoidance vector for AvoidEntityMS

### DIFF
--- a/include/scrimmage/plugins/autonomy/AvoidEntityMS/AvoidEntityMS.h
+++ b/include/scrimmage/plugins/autonomy/AvoidEntityMS/AvoidEntityMS.h
@@ -53,6 +53,7 @@ class AvoidEntityMS : public scrimmage::autonomy::motor_schemas::BehaviorBase {
     bool avoid_non_team_;
 
     scrimmage_proto::ShapePtr circle_shape_ = std::make_shared<scrimmage_proto::Shape>();
+    scrimmage_proto::ShapePtr line_shape_ = std::make_shared<scrimmage_proto::Shape>();
 
     bool show_shapes_ = false;
 };

--- a/src/plugins/autonomy/AvoidEntityMS/AvoidEntityMS.cpp
+++ b/src/plugins/autonomy/AvoidEntityMS/AvoidEntityMS.cpp
@@ -117,6 +117,13 @@ bool AvoidEntityMS::step_autonomy(double t, double dt) {
         circle_shape_->mutable_circle()->set_radius(sphere_of_influence_);
         sc::set(circle_shape_->mutable_circle()->mutable_center(), state_->pos());
         draw_shape(circle_shape_);
+
+        line_shape_->set_persistent(true);
+        sc::set(line_shape_->mutable_color(), 255, 0, 0);
+        line_shape_->set_opacity(0.75);
+        sc::set(line_shape_->mutable_line()->mutable_start(), state_->pos());
+        sc::set(line_shape_->mutable_line()->mutable_end(), desired_vector_ + state_->pos());
+        draw_shape(line_shape_);
     }
 
     return true;


### PR DESCRIPTION
Optionally draw the Avoidance vector in red when using AvoidEntityMS from MotorSchemas