### PR TITLE
switch to rapidxml included with boost

### DIFF
--- a/ci/dockerfiles/centos6
+++ b/ci/dockerfiles/centos6
@@ -180,23 +180,6 @@ RUN source /etc/profile.d/rvm.sh && cd /root/installs/geographiclib \
     && rpm -ivh /root/installs/geographiclib/*.rpm
 
 ###############################################################################
-# RapidXML Package
-###############################################################################
-WORKDIR /root/3rd-party
-RUN git clone https://github.com/dwd/rapidxml.git && cd rapidxml \
-    && git checkout f0058ab9374643018c1db3de521e44d4d52b8f5d
-RUN rm -rf ./rapidxml/{.git,test}
-RUN mkdir -p /root/installs/rapidxml${PKG_PREFIX}/include \
-    && cp -r ./rapidxml /root/installs/rapidxml${PKG_PREFIX}/include
-
-# Build RPM package for rapidxml
-RUN source /etc/profile.d/rvm.sh && cd /root/installs/rapidxml \
-    && fpm --force --input-type dir --output-type rpm \
-           --name scrimmage-rapidxml --version 1.00 \
-           --package scrimmage_rapidxml_VERSION_ARCH.rpm .${PKG_PREFIX}/=${PKG_PREFIX} \
-    && rpm -ivh /root/installs/rapidxml/*.rpm
-
-###############################################################################
 # Build PyBind11
 ###############################################################################
 WORKDIR /root/3rd-party

--- a/ci/dockerfiles/ubuntu-18.04
+++ b/ci/dockerfiles/ubuntu-18.04
@@ -15,7 +15,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     git \
     libgrpc++-dev \
     libeigen3-dev \
-    librapidxml-dev \
     libboost-thread-dev \
     libboost-date-time-dev \
     libboost-graph-dev \

--- a/include/scrimmage/parse/ConfigParse.h
+++ b/include/scrimmage/parse/ConfigParse.h
@@ -37,9 +37,14 @@
 #include <vector>
 #include <string>
 
+namespace boost {
+namespace property_tree {
+namespace detail {
 namespace rapidxml {
 template <class T> class xml_node;
-}
+}}}}
+
+namespace rapidxml = boost::property_tree::detail::rapidxml;
 
 namespace scrimmage {
 

--- a/setup/install-binaries.sh
+++ b/setup/install-binaries.sh
@@ -36,7 +36,7 @@ usage()
 {
     cat << EOF
 usage: sudo $0 -e
-This script installs all required dependencies. 
+This script installs all required dependencies.
 
 OPTIONS
 
@@ -46,7 +46,7 @@ OPTIONS
         installation.
 
     --python <number>
-        install dependencies for python version <number>. This will install 
+        install dependencies for python version <number>. This will install
         dependencies from apt for this version of python (e.g.,
         apt install python<number>-numpy). Options are "2, 3, a"
         with "a" installing dependencies for both python 2 and 3.
@@ -65,7 +65,6 @@ DEPS_DPKG=(
     cmake
     gcc
     build-essential
-    librapidxml-dev
     libeigen3-dev
     libgeographic-dev
     libboost-thread-dev
@@ -102,7 +101,7 @@ if [[ "$1" = "--python" ]]; then
     PYTHON_VERSION="$2"
 elif  [[ "$3" = "--python" ]]; then
     PYTHON_VERSION="$4"
-fi 
+fi
 
 if [[ "$PYTHON_VERSION" = "2" ]] || [[ "$PYTHON_VERSION" = "a" ]]; then
     DEPS_DPKG+=(
@@ -119,7 +118,7 @@ if [[ "$PYTHON_VERSION" = "2" ]] || [[ "$PYTHON_VERSION" = "a" ]]; then
     )
 fi
 
-if [[ "$PYTHON_VERSION" -eq "3" ]] || [[ "$PYTHON_VERSION" = "a" ]]; then 
+if [[ "$PYTHON_VERSION" -eq "3" ]] || [[ "$PYTHON_VERSION" = "a" ]]; then
     DEPS_DPKG+=(
         python3
         python3-setuptools
@@ -257,8 +256,8 @@ fi
 ########################
 if [[ "$PYTHON_VERSION" = "2" ]] || [[ "$PYTHON_VERSION" = "a" ]]; then
     pip install sphinx-git pydoe
-fi 
+fi
 
 if [[ "$PYTHON_VERSION" = "3" ]] || [[ "$PYTHON_VERSION" = "a" ]]; then
     pip3 install sphinx-git pydoe
-fi 
+fi

--- a/src/parse/ConfigParse.cpp
+++ b/src/parse/ConfigParse.cpp
@@ -44,10 +44,10 @@
 #undef BOOST_NO_CXX11_SCOPED_ENUMS
 #include <boost/algorithm/string.hpp>
 
-#include <rapidxml/rapidxml.hpp>
+#include <boost/property_tree/detail/rapidxml.hpp>
 
 namespace fs = boost::filesystem;
-namespace rx = rapidxml;
+namespace rx = boost::property_tree::detail::rapidxml;
 
 using std::cout;
 using std::endl;

--- a/src/parse/MissionParse.cpp
+++ b/src/parse/MissionParse.cpp
@@ -51,13 +51,13 @@
 #include <boost/filesystem.hpp>
 #undef BOOST_NO_CXX11_SCOPED_ENUMS
 
-#include <rapidxml/rapidxml.hpp>
+#include <boost/property_tree/detail/rapidxml.hpp>
 
 using std::cout;
 using std::endl;
 
 namespace fs = boost::filesystem;
-namespace rx = rapidxml;
+namespace rapidxml = boost::property_tree::detail::rapidxml;
 
 namespace scrimmage {
 
@@ -143,11 +143,11 @@ bool MissionParse::parse(const std::string &filename) {
 
     // param_common name: tag: value
     std::map<std::string, std::map<std::string, std::string>> param_common;
-    for (rx::xml_node<> *script_node = runscript_node->first_node("param_common");
+    for (rapidxml::xml_node<> *script_node = runscript_node->first_node("param_common");
          script_node != 0;
          script_node = script_node->next_sibling("param_common")) {
 
-        rx::xml_attribute<> *nm_attr = script_node->first_attribute("name");
+        rapidxml::xml_attribute<> *nm_attr = script_node->first_attribute("name");
         if (nm_attr == 0) {
             std::cout << "warning: found param_common block without a name, skipping" << std::endl;
             continue;
@@ -155,7 +155,7 @@ bool MissionParse::parse(const std::string &filename) {
 
         std::string nm = nm_attr->value();
 
-        for (rx::xml_node<> *node = script_node->first_node(); node != 0;
+        for (rapidxml::xml_node<> *node = script_node->first_node(); node != 0;
              node = node->next_sibling()) {
 
             param_common[nm][node->name()] = node->value();


### PR DESCRIPTION
This commit switches to using the rapidxml that is packaged with boost in the property_tree library. Since we already depend on boost headers, this removes a dependency; also, it allows rapidxml to be used easily on macOS. Presently, there is no good way to install rapidxml on macOS (we've been manually copying the headers for every install). I was prompted to find a better solution by a user who's [trying to build and use scrimmage on mac.](https://github.com/crichardson332/homebrew-crich_brews/issues/1) 

What do you guys think?

