### PR TITLE
fix compiler flags for macOS in cmake proj

### DIFF
--- a/scripts/templates/cmake-project/missions/example.xml
+++ b/scripts/templates/cmake-project/missions/example.xml
@@ -39,6 +39,8 @@
 
   <!-- uncomment "seed" and use integer for deterministic results -->
   <seed>2147483648</seed>
+  <network>GlobalNetwork</network>
+  <network>LocalNetwork</network>
 
   <!-- ========================== TEAM 1 ========================= -->
   <entity>

--- a/scripts/templates/cmake-project/msgs/CMakeLists.txt
+++ b/scripts/templates/cmake-project/msgs/CMakeLists.txt
@@ -94,6 +94,10 @@ target_link_libraries(${LIBRARY_NAME}
 
 SET (_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})
 
+target_compile_features(${LIBRARY_NAME}
+  PRIVATE cxx_std_11
+  )
+
 set_target_properties(
   ${LIBRARY_NAME}
   PROPERTIES


### PR DESCRIPTION
This commit fixes build issues in the generated cmake project on clang.