### PR TITLE
volkswagen typo

### DIFF
--- a/docs/source/overview/xml-tags.rst
+++ b/docs/source/overview/xml-tags.rst
@@ -240,7 +240,7 @@ and match between the two paradigms for a single entity.
       motion planning.
 
   - ``visual_model`` : Loads an XML file that specifies the appearance of the
-    entity. Examples: zephyr-blue, zephyr-red, iris, sea-angler, volkswagon.
+    entity. Examples: zephyr-blue, zephyr-red, iris, sea-angler, volkswagen.
 
   - ``controller`` : Loads a low-level controller plugin. Each entity can only
     have a single controller.


### PR DESCRIPTION
Fixed a typo: "volkswagon" to "volkswagen"