### PR TITLE
Add simple attrition plugin that removes entities from a team over time

### DIFF
--- a/include/scrimmage/plugins/interaction/RandomAttrit/RandomAttrit.h
+++ b/include/scrimmage/plugins/interaction/RandomAttrit/RandomAttrit.h
@@ -1,0 +1,73 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Jeremy Feltracco <jeremy.feltracco@gtri.gatech.edu>
+ * @date 06 December 2018
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#ifndef INCLUDE_SCRIMMAGE_PLUGINS_INTERACTION_RANDOMATTRIT_RANDOMATTRIT_H_
+#define INCLUDE_SCRIMMAGE_PLUGINS_INTERACTION_RANDOMATTRIT_RANDOMATTRIT_H_
+
+#include <scrimmage/simcontrol/EntityInteraction.h>
+#include <scrimmage/entity/Entity.h>
+#include <scrimmage/common/Random.h>
+#include <scrimmage/pubsub/PubSub.h>
+#include <scrimmage/pubsub/Publisher.h>
+
+#include <map>
+#include <list>
+#include <string>
+#include <vector>
+
+namespace scrimmage {
+namespace interaction {
+
+class RandomAttrit : public scrimmage::EntityInteraction {
+ public:
+    RandomAttrit();
+    bool init(std::map<std::string, std::string> &mission_params,
+              std::map<std::string, std::string> &plugin_params) override;
+    bool step_entity_interaction(std::list<scrimmage::EntityPtr> &ents,
+                                 double t, double dt) override;
+ protected:
+    bool started_ = false;
+    int team_id_ = -1;
+    std::string decay_method_ = "";
+    double start_wait_time_s_ = 0.0;
+    double duration_s_ = 10.0;
+    std::vector<int> stay_alive_ids_;
+    int total_num_entities_ = 0;
+    double start_num_ent_ = 0.0;
+    double num_ent_ = 0.0;
+    Random random_;
+
+    PublisherPtr attrit_pub_;
+ private:
+};
+} // namespace interaction
+} // namespace scrimmage
+#endif // INCLUDE_SCRIMMAGE_PLUGINS_INTERACTION_RANDOMATTRIT_RANDOMATTRIT_H_

--- a/include/scrimmage/plugins/interaction/RandomAttrit/RandomAttrit.xml
+++ b/include/scrimmage/plugins/interaction/RandomAttrit/RandomAttrit.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
+<params>
+  <library>RandomAttrit_plugin</library>
+
+  <decay_method>linear</decay_method>
+  <!-- <decay_method>exponential</decay_method> -->
+
+  <!-- Wait this many seconds before starting to begin attrit -->
+  <start_after>5.0</start_after>
+  <!-- Perform attrition down to the "leave_alive" entities within this time frame -->
+  <duration>30.0</duration>
+
+  <!-- Which team to attrit -->
+  <team>1</team>
+
+  <!-- Pick individual entities to stay alive, leave empty if none -->
+  <leave_alive>1 2</leave_alive>
+</params>

--- a/missions/random-attrit-test.xml
+++ b/missions/random-attrit-test.xml
@@ -1,0 +1,130 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
+<runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    name="Random Attrit">
+
+  <run start="0.0" end="100" dt="0.1"
+       time_warp="10"
+       enable_gui="true"
+       network_gui="false"
+       start_paused="true"/>
+
+  <multi_threaded num_threads="8">false</multi_threaded>
+  <stream_port>50051</stream_port>
+  <stream_ip>localhost</stream_ip>
+
+  <end_condition>time, all_dead</end_condition> <!-- time, one_team, none-->
+
+  <grid_spacing>10</grid_spacing>
+  <grid_size>1000</grid_size>
+
+  <terrain>mcmillan</terrain>
+  <background_color>191 191 191</background_color> <!-- Red Green Blue -->
+  <gui_update_period>10</gui_update_period> <!-- milliseconds -->
+
+  <plot_tracks>false</plot_tracks>
+  <output_type>all</output_type>
+  <show_plugins>false</show_plugins>
+
+  <metrics>SimpleCollisionMetrics</metrics>
+
+  <log_dir>~/.scrimmage/logs</log_dir>
+  <create_latest_dir>true</create_latest_dir>
+
+  <latitude_origin>35.721025</latitude_origin>
+  <longitude_origin>-120.767925</longitude_origin>
+  <altitude_origin>300</altitude_origin>
+  <show_origin>true</show_origin>
+  <origin_length>10</origin_length>
+
+  <entity_interaction type="cuboid"
+                      lengths="2000, 2000, 1000"
+                      center="0, 0, 500"
+                      rpy="0, 0, 0"
+                      >Boundary</entity_interaction>
+  <entity_interaction>SimpleCollision</entity_interaction>
+  <entity_interaction>GroundCollision</entity_interaction>
+  
+  <enable_screenshots min_period="1.0" start="8.3" end="15.3">false</enable_screenshots>
+
+  <network>GlobalNetwork</network>
+  <network>LocalNetwork</network>
+  
+  <!-- uncomment "seed" and use integer for deterministic results -->
+  <seed>2147483648</seed>
+
+  <entity_interaction decay_method="linear"
+                      start_after="2"
+                      duration="60.0"
+                      team="1"
+                      leave_alive="1 2">RandomAttrit</entity_interaction>
+
+  <!-- ========================== TEAM 1 ========================= -->
+  <entity>
+    <name>uav_entity</name>
+    <team_id>1</team_id>
+    <color>77 77 255</color>
+    <count>30</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <variance_x>20</variance_x>
+    <variance_y>20</variance_y>
+    <variance_z>10</variance_z>
+
+    <x>-900</x>
+    <y>0</y>
+    <z>195</z>
+    <heading>0</heading>
+
+    <controller>SimpleAircraftControllerPID</controller>
+    <motion_model>SimpleAircraft</motion_model>
+
+    <visual_model>zephyr-blue</visual_model>
+
+    <sensor>NoisyState</sensor>
+    <sensor>NoisyContacts</sensor>
+    <!--<sensor>ContactBlobCamera</sensor>-->
+
+    <autonomy show_text_label="true"
+              enable_boundary_control="true">Straight</autonomy>
+
+    <base>
+      <latitude>35.721112</latitude>
+      <longitude>-120.770305</longitude>
+      <altitude>300</altitude>
+      <radius>25</radius>
+    </base>
+  </entity>
+
+  <entity>
+    <team_id>2</team_id>
+    <color>255 0 0</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>2</radius>
+
+    <variance_x>20</variance_x>
+    <variance_y>20</variance_y>
+    <variance_z>20</variance_z>
+
+    <x>50</x>
+    <y>0</y>
+    <z>200</z>
+
+    <heading>180</heading>
+    <altitude>200</altitude>
+    <controller>SimpleAircraftControllerPID</controller>
+    <motion_model>SimpleAircraft</motion_model>
+    <visual_model>zephyr-red</visual_model>
+    <autonomy speed="21"
+              enable_boundary_control="true">Straight</autonomy>
+    <base>
+      <latitude>35.719961</latitude>
+      <longitude>-120.767304</longitude>
+      <altitude>300</altitude>
+      <radius>25</radius>
+    </base>
+  </entity>
+    
+</runscript>

--- a/src/plugins/interaction/RandomAttrit/CMakeLists.txt
+++ b/src/plugins/interaction/RandomAttrit/CMakeLists.txt
@@ -1,0 +1,45 @@
+#--------------------------------------------------------
+# Library Creation
+#--------------------------------------------------------
+set(LIBRARY_NAME RandomAttrit_plugin)
+set(LIB_MAJOR 0)
+set(LIB_MINOR 0)
+set(LIB_RELEASE 1)
+
+file(GLOB SRCS *.cpp)
+
+add_library(${LIBRARY_NAME} SHARED
+  ${SRCS}
+)
+
+target_compile_options(${LIBRARY_NAME}
+  PRIVATE -Wall -Wno-return-type-c-linkage -std=c++14
+)
+
+target_link_libraries(${LIBRARY_NAME}
+  scrimmage-core
+)
+
+set(_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})
+
+set_target_properties(${LIBRARY_NAME} PROPERTIES
+  SOVERSION ${LIB_MAJOR}
+  VERSION ${_soversion}
+  LIBRARY_OUTPUT_DIRECTORY ${PROJECT_PLUGIN_LIBS_DIR}
+)
+
+target_include_directories(${LIBRARY_NAME}
+  PUBLIC
+    $<INSTALL_INTERFACE:include>
+    $<BUILD_INTERFACE:${PROJECT_INC_DIR}>
+)
+
+install(TARGETS ${LIBRARY_NAME}
+  # IMPORTANT: Add the library to the "export-set"
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib/${PROJECT_NAME}/plugin_libs
+)
+
+# Push up the PROJECT_PLUGINS variable
+set(PROJECT_PLUGINS ${PROJECT_PLUGINS} ${LIBRARY_NAME} PARENT_SCOPE)

--- a/src/plugins/interaction/RandomAttrit/RandomAttrit.cpp
+++ b/src/plugins/interaction/RandomAttrit/RandomAttrit.cpp
@@ -1,0 +1,127 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Jeremy Feltracco <jeremy.feltracco@gtri.gatech.edu>
+ * @date 06 December 2018
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#include <scrimmage/plugins/interaction/RandomAttrit/RandomAttrit.h>
+
+#include <scrimmage/common/Utilities.h>
+#include <scrimmage/entity/Entity.h>
+#include <scrimmage/plugin_manager/RegisterPlugin.h>
+#include <scrimmage/math/State.h>
+#include <scrimmage/parse/ParseUtils.h>
+#include <scrimmage/common/Random.h>
+
+#include <memory>
+#include <limits>
+#include <iostream>
+#include <cmath>
+
+using std::cout;
+using std::endl;
+
+namespace sc = scrimmage;
+
+REGISTER_PLUGIN(scrimmage::EntityInteraction,
+                scrimmage::interaction::RandomAttrit,
+                RandomAttrit_plugin)
+
+namespace scrimmage {
+namespace interaction {
+
+RandomAttrit::RandomAttrit() {
+}
+
+bool RandomAttrit::init(std::map<std::string, std::string> &mission_params,
+                               std::map<std::string, std::string> &plugin_params) {
+    team_id_ = sc::get("team", plugin_params, -1);
+    decay_method_ = sc::get("decay_method", plugin_params, "linear");
+    start_wait_time_s_ = sc::get("start_after", plugin_params, 0.0);
+    duration_s_ = sc::get("duration", plugin_params, 10.0);
+    std::vector<std::string> stay_alive_ids_str;
+    sc::get_vec("leave_alive", plugin_params, " ", stay_alive_ids_str);
+    std::transform(stay_alive_ids_str.begin(), stay_alive_ids_str.end(),
+                   std::back_inserter(stay_alive_ids_),
+                   [](const std::string& str) { return std::stoi(str); });
+
+    attrit_pub_ = advertise("GlobalNetwork", "AttritAnnounce");
+    return true;
+}
+
+
+bool RandomAttrit::step_entity_interaction(std::list<sc::EntityPtr> &ents,
+                                                  double t, double dt) {
+    if (ents.empty() || num_ent_ < 0.0) {
+        return true;
+    }
+
+    total_num_entities_ = 0;
+    std::vector<sc::EntityPtr> cur_ents;
+    std::copy_if(ents.begin(), ents.end(), std::back_inserter(cur_ents),
+         [&](const sc::EntityPtr& ent) {
+             bool is_stay_alive = std::find(stay_alive_ids_.begin(), stay_alive_ids_.end(),
+                                            ent->id().id()) != stay_alive_ids_.end();
+             bool team_match = ent->id().team_id() == team_id_;
+             if (team_match) total_num_entities_++;
+             return !is_stay_alive && team_match;
+         });
+
+    if (t < start_wait_time_s_) {
+        return true;
+    } else if (!started_) {
+        // one time initialization
+        start_num_ent_ = cur_ents.size();
+        num_ent_ = start_num_ent_;
+        started_ = true;
+    }
+
+    if (decay_method_ == "linear") {
+        double slope = -start_num_ent_ / duration_s_;
+        num_ent_ = slope * (t - start_wait_time_s_) + start_num_ent_;
+    } else {
+        std::cout << "RandomAttrit: Decay method, " << decay_method_
+                  << ", is not implemented." << std::endl;
+    }
+
+    // else if (decay_method_ == "exponential") {
+
+    if (std::ceil(num_ent_) < cur_ents.size()) {
+        // pick one to attrit
+        int drop_id = random_.rng_uniform_int(0, cur_ents.size() - 1);
+        cur_ents[drop_id]->set_health_points(-1); // kill entity
+
+        auto msg = std::make_shared<sc::Message<EntityPtr>>();
+        msg->data = cur_ents[drop_id];
+        attrit_pub_->publish(msg);
+    }
+
+    return true;
+}
+} // namespace interaction
+} // namespace scrimmage


### PR DESCRIPTION
Bare bones attrition plugin. A user specifies the time at which entity removal should start, how long it should last, a team, and any entities that should be "saved" from the removal, and the plugin will remove entities until down to the "leave_alive" entities.

Every time an entity gets removed, this publishes a message containing a pointer to the entity about to be removed.