### PR TITLE
Removed unnecessary link to Boundary_plugin in the CMakeLists.txt of several plugins

### DIFF
--- a/src/plugins/autonomy/BoundaryDefense/CMakeLists.txt
+++ b/src/plugins/autonomy/BoundaryDefense/CMakeLists.txt
@@ -18,7 +18,6 @@ target_compile_options(${LIBRARY_NAME}
 
 target_link_libraries(${LIBRARY_NAME}
   scrimmage-core
-  Boundary_plugin
 )
 
 set(_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})

--- a/src/plugins/autonomy/Straight/CMakeLists.txt
+++ b/src/plugins/autonomy/Straight/CMakeLists.txt
@@ -13,7 +13,6 @@ ADD_LIBRARY(${LIBRARY_NAME} SHARED
   )
 
 TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
-  Boundary_plugin
   scrimmage-core
   )
 

--- a/src/plugins/autonomy/TakeFlag/CMakeLists.txt
+++ b/src/plugins/autonomy/TakeFlag/CMakeLists.txt
@@ -18,7 +18,6 @@ target_compile_options(${LIBRARY_NAME}
 
 target_link_libraries(${LIBRARY_NAME}
   scrimmage-core
-  Boundary_plugin
 )
 
 set(_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})

--- a/src/plugins/interaction/CaptureInBoundaryInteraction/CMakeLists.txt
+++ b/src/plugins/interaction/CaptureInBoundaryInteraction/CMakeLists.txt
@@ -14,7 +14,6 @@ ADD_LIBRARY(${LIBRARY_NAME} SHARED
 
 TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
     scrimmage-core
-  Boundary_plugin
   )
 
 SET (_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})

--- a/src/plugins/interaction/EnforceBoundaryInteraction/CMakeLists.txt
+++ b/src/plugins/interaction/EnforceBoundaryInteraction/CMakeLists.txt
@@ -14,7 +14,6 @@ ADD_LIBRARY(${LIBRARY_NAME} SHARED
 
 TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
     scrimmage-core
-  Boundary_plugin
   )
 
 SET (_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})

--- a/src/plugins/interaction/FlagCaptureInteraction/CMakeLists.txt
+++ b/src/plugins/interaction/FlagCaptureInteraction/CMakeLists.txt
@@ -14,7 +14,6 @@ ADD_LIBRARY(${LIBRARY_NAME} SHARED
 
 TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
     scrimmage-core
-  Boundary_plugin
   )
 
 SET (_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})


### PR DESCRIPTION
The following CMakeLists.txt files unneccesarily link to Boundary_plugin:
- plugins/autonomy/BoundaryDefense
- plugins/autonomy/Straight
- plugins/autonomy/TakeFlag
- plugins/interaction/CaptureInBoundaryInteraction
- plugins/interaction/EnforceBoundaryInteraction
- plugins/interaction/FlagCaptureInteraction