### PR TITLE
Patch segfaulting when losing entities on sphere network

### DIFF
--- a/src/plugins/network/LocalNetwork/LocalNetwork.cpp
+++ b/src/plugins/network/LocalNetwork/LocalNetwork.cpp
@@ -71,6 +71,8 @@ bool LocalNetwork::init(std::map<std::string, std::string> &mission_params,
 
 bool LocalNetwork::is_reachable(const scrimmage::PluginPtr &pub_plugin,
                                 const scrimmage::PluginPtr &sub_plugin) {
+    // Never reachable if plugin's entity was destroyed
+    if (pub_plugin->parent() == nullptr || sub_plugin->parent() == nullptr) return false;
     // If the publisher and subscriber have the same parent, it is reachable
     return (pub_plugin->parent() == sub_plugin->parent());
 }

--- a/src/plugins/network/SphereNetwork/SphereNetwork.cpp
+++ b/src/plugins/network/SphereNetwork/SphereNetwork.cpp
@@ -79,6 +79,8 @@ bool SphereNetwork::init(std::map<std::string, std::string> &mission_params,
 
 bool SphereNetwork::is_reachable(const scrimmage::PluginPtr &pub_plugin,
                                  const scrimmage::PluginPtr &sub_plugin) {
+    // Never reachable if plugin's entity was destroyed
+    if (pub_plugin->parent() == nullptr || sub_plugin->parent() == nullptr) return false;
     // If the publisher and subscriber have the same parent, it is reachable
     if (pub_plugin->parent() == sub_plugin->parent()) return true;
 


### PR DESCRIPTION
At least in the case when entities collide and are set inactive, pub/sub plugins in the pubsub map in SimControl have their parent entity closed, but they stay in the pubsub map. This causes a null pointer deref when something tries to refer to the parent object of the one of these publisher or subscribers.