### PR TITLE
Added various error checks in MissionParse and External.

### DIFF
--- a/include/scrimmage/entity/External.h
+++ b/include/scrimmage/entity/External.h
@@ -178,7 +178,8 @@ class External {
         boost::optional<std::list<NetworkDevicePtr>> subs =
             pubsub_->find_subs(network_name, topic_name);
 
-        auto no_subs_msg = [&]() {
+        auto no_subs_msg = [=]() { //capture by copy, used in returned function.
+            //Note: Find_subs already prints this information. Keep it here or there?
             std::cout << "No subscribers exist in SCRIMMAGE" << std::endl;
             std::cout << "Network name: " << network_name << std::endl;
             std::cout << "Topic name: " << topic_name << std::endl;
@@ -346,7 +347,7 @@ class External {
 #endif
 
  protected:
-    void call_update_contacts(double t);
+    bool call_update_contacts(double t); //false on error
     void update_time(double t);
 
     std::list<InterfacePtr> outgoing_interfaces_;

--- a/include/scrimmage/entity/External.h
+++ b/include/scrimmage/entity/External.h
@@ -178,22 +178,10 @@ class External {
         boost::optional<std::list<NetworkDevicePtr>> subs =
             pubsub_->find_subs(network_name, topic_name);
 
-        auto no_subs_msg = [=]() { //capture by copy, used in returned function.
-            //Note: Find_subs already prints this information. Keep it here or there?
-            std::cout << "No subscribers exist in SCRIMMAGE" << std::endl;
-            std::cout << "Network name: " << network_name << std::endl;
-            std::cout << "Topic name: " << topic_name << std::endl;
-        };
-
-        if (!subs) {
-            no_subs_msg();
-        }
-
         return [=](const boost::shared_ptr<RosType const> &ros_msg) {
             boost::optional<std::list<NetworkDevicePtr>> curr_subs =
                 pubsub_->find_subs(network_name, topic_name);
             if (!curr_subs) {
-                no_subs_msg();
                 return;
             }
 
@@ -347,7 +335,7 @@ class External {
 #endif
 
  protected:
-    bool call_update_contacts(double t); //false on error
+    bool call_update_contacts(double t); // false on error
     void update_time(double t);
 
     std::list<InterfacePtr> outgoing_interfaces_;

--- a/src/entity/External.cpp
+++ b/src/entity/External.cpp
@@ -255,7 +255,7 @@ bool External::step(double t) {
     last_t_ = t;
     mutex.unlock();
 
-    if(!this->call_update_contacts(t)) return false;
+    if (!this->call_update_contacts(t)) return false;
 
     mutex.lock();
 
@@ -379,8 +379,8 @@ bool External::send_messages() {
 bool External::call_update_contacts(double t) {
     mutex.lock();
     if (update_contacts_task.update(t).first) {
-        auto rtree = entity_->rtree(); //rtree is a shared_ptr
-        if(!rtree) {mutex.unlock(); return false;}
+        auto rtree = entity_->rtree(); // rtree is a shared_ptr
+        if (!rtree) {mutex.unlock(); return false;}
         rtree->init(100);
         rtree->clear();
         for (auto &kv : *entity_->contacts()) {

--- a/src/entity/External.cpp
+++ b/src/entity/External.cpp
@@ -255,7 +255,7 @@ bool External::step(double t) {
     last_t_ = t;
     mutex.unlock();
 
-    this->call_update_contacts(t);
+    if(!this->call_update_contacts(t)) return false;
 
     mutex.lock();
 
@@ -296,7 +296,7 @@ bool External::step(double t) {
         metrics->step_metrics(t, dt);
     }
 
-    if (!send_messages()) {return false;}
+    if (!send_messages()) {mutex.unlock(); return false;}
 
     // shapes
     scrimmage_proto::Shapes shapes;
@@ -376,10 +376,11 @@ bool External::send_messages() {
     return true;
 }
 
-void External::call_update_contacts(double t) {
+bool External::call_update_contacts(double t) {
     mutex.lock();
     if (update_contacts_task.update(t).first) {
-        auto rtree = entity_->rtree();
+        auto rtree = entity_->rtree(); //rtree is a shared_ptr
+        if(!rtree) {mutex.unlock(); return false;}
         rtree->init(100);
         rtree->clear();
         for (auto &kv : *entity_->contacts()) {
@@ -388,6 +389,7 @@ void External::call_update_contacts(double t) {
         update_ents();
     }
     mutex.unlock();
+    return true;
 }
 
 MissionParsePtr External::mp() {

--- a/src/parse/MissionParse.cpp
+++ b/src/parse/MissionParse.cpp
@@ -126,11 +126,20 @@ bool MissionParse::parse(const std::string &filename) {
     std::regex reg("\\$\\{.+?=(.+?)\\}");
     mission_file_content_ = std::regex_replace(mission_file_content_, reg, fmt);
 
-    // Make a copy of the content since the xml parser can mangle the original
-    // content.
-    std::string content_tmp(mission_file_content_);
+    //Parse the xml tree.
     rapidxml::xml_document<> doc;
-    doc.parse<0>(&content_tmp[0]);
+    //doc.parse requires a null terminated string that it can modify.
+    std::vector<char> mission_file_content_vec(mission_file_content_.size() + 1); //allocation done here
+    mission_file_content_vec.assign(mission_file_content_.begin(), mission_file_content_.end()); //copy
+    mission_file_content_vec.push_back('\0'); //shouldn't reallocate
+    try {
+      //Note: This parse function can hard fail (seg fault, no exception) on
+      //      badly formatted xml data. Sometimes it'll except, sometimes not.
+      doc.parse<0>(mission_file_content_vec.data());
+    } catch (...) {
+      cout << "scrimmage::MissionParse::parse: Exception during rapidxml::xml_document<>.parse<>()." << endl;
+      return false;
+    }
 
     rapidxml::xml_node<> *runscript_node = doc.first_node("runscript");
     if (runscript_node == 0) {

--- a/src/parse/MissionParse.cpp
+++ b/src/parse/MissionParse.cpp
@@ -126,19 +126,19 @@ bool MissionParse::parse(const std::string &filename) {
     std::regex reg("\\$\\{.+?=(.+?)\\}");
     mission_file_content_ = std::regex_replace(mission_file_content_, reg, fmt);
 
-    //Parse the xml tree.
+    // Parse the xml tree.
     rapidxml::xml_document<> doc;
-    //doc.parse requires a null terminated string that it can modify.
-    std::vector<char> mission_file_content_vec(mission_file_content_.size() + 1); //allocation done here
-    mission_file_content_vec.assign(mission_file_content_.begin(), mission_file_content_.end()); //copy
-    mission_file_content_vec.push_back('\0'); //shouldn't reallocate
+    // doc.parse requires a null terminated string that it can modify.
+    std::vector<char> mission_file_content_vec(mission_file_content_.size() + 1); // allocation done here
+    mission_file_content_vec.assign(mission_file_content_.begin(), mission_file_content_.end()); // copy
+    mission_file_content_vec.push_back('\0'); // shouldn't reallocate
     try {
-      //Note: This parse function can hard fail (seg fault, no exception) on
-      //      badly formatted xml data. Sometimes it'll except, sometimes not.
-      doc.parse<0>(mission_file_content_vec.data());
+        // Note: This parse function can hard fail (seg fault, no exception) on
+        //       badly formatted xml data. Sometimes it'll except, sometimes not.
+        doc.parse<0>(mission_file_content_vec.data());
     } catch (...) {
-      cout << "scrimmage::MissionParse::parse: Exception during rapidxml::xml_document<>.parse<>()." << endl;
-      return false;
+        cout << "scrimmage::MissionParse::parse: Exception during rapidxml::xml_document<>.parse<>()." << endl;
+        return false;
     }
 
     rapidxml::xml_node<> *runscript_node = doc.first_node("runscript");


### PR DESCRIPTION
Added checks for xml parsing errors in MissionParse. However, note that sometimes it hard crashes, sometimes not.
Fixed sub_cb return that was getting bad data from a bad lambda.
Added error checking in the External step function, to catch the case where scrimmage was not setup properly. Also found a missing mutex unlock.