### PR TITLE
clean up const functions in State

### DIFF
--- a/include/scrimmage/math/State.h
+++ b/include/scrimmage/math/State.h
@@ -55,15 +55,19 @@ class State {
     Eigen::Vector3d &pos();
     Eigen::Vector3d &vel();
     Eigen::Vector3d &ang_vel();
+    const Eigen::Vector3d &pos() const;
+    const Eigen::Vector3d &vel() const;
+    const Eigen::Vector3d &ang_vel() const;
 
     // Converts between local level (East/North/Up) and body (Nose/Left/Up)
     Quaternion &quat();
+    const Quaternion &quat() const;
 
+    // for backwards compatibility
     const Eigen::Vector3d &pos_const() const;
     const Eigen::Vector3d &vel_const() const;
     const Eigen::Vector3d &ang_vel_const() const;
     const Quaternion &quat_const() const;
-
     void set_pos(const Eigen::Vector3d &pos);
     void set_vel(const Eigen::Vector3d &vel);
     void set_ang_vel(const Eigen::Vector3d &ang_vel);

--- a/include/scrimmage/viewer/Updater.h
+++ b/include/scrimmage/viewer/Updater.h
@@ -102,6 +102,11 @@ class Updater : public vtkCommand {
 
     Updater();
 
+    static void set_quat(const scrimmage_proto::Quaternion &quat,
+                         vtkSmartPointer<vtkActor> &actor);
+    static void set_quat(const scrimmage::Quaternion &quat,
+                         vtkSmartPointer<vtkActor> &actor);
+
     void Execute(vtkObject *caller, unsigned long vtkNotUsed(eventId), // NOLINT
                  void * vtkNotUsed(callData));
 

--- a/python/scrimmage/bindings/src/py_math.cpp
+++ b/python/scrimmage/bindings/src/py_math.cpp
@@ -69,10 +69,14 @@ void add_math(pybind11::module &m) {
         .def(py::init<Eigen::Vector3d, Eigen::Vector3d, Eigen::Vector3d,
              sc::Quaternion>(), py::arg("position"), py::arg("velocity"),
              py::arg("angular_velocity"), py::arg("orientation"))
-        .def_property("pos", &sc::State::pos, &sc::State::set_pos)
-        .def_property("vel", &sc::State::vel, &sc::State::set_vel)
-        .def_property("ang_vel", &sc::State::ang_vel, &sc::State::set_ang_vel)
-        .def_property("quat", &sc::State::quat, &sc::State::set_quat)
+        .def("pos_mutable", py::overload_cast<>(&sc::State::pos))
+        .def("vel_mutable", py::overload_cast<>(&sc::State::vel))
+        .def("ang_vel_mutable", py::overload_cast<>(&sc::State::ang_vel))
+        .def("quat_mutable", py::overload_cast<>(&sc::State::quat))
+        .def("pos_const", py::overload_cast<>(&sc::State::pos, py::const_))
+        .def("vel_const", py::overload_cast<>(&sc::State::vel, py::const_))
+        .def("ang_vel_const", py::overload_cast<>(&sc::State::ang_vel, py::const_))
+        .def("quat_const", py::overload_cast<>(&sc::State::quat, py::const_))
         .def("in_field_of_view", &sc::State::InFieldOfView)
         .def("rel_pos_local_frame", &sc::State::rel_pos_local_frame)
         .def("orient_global_frame", &sc::State::orient_global_frame);

--- a/src/math/State.cpp
+++ b/src/math/State.cpp
@@ -48,26 +48,22 @@ State::State(Eigen::Vector3d _pos, Eigen::Vector3d _vel,
 State::~State() {}
 
 Eigen::Vector3d &State::pos() {return pos_;}
-
 Eigen::Vector3d &State::vel() {return vel_;}
 Eigen::Vector3d &State::ang_vel() {return ang_vel_;}
-
 Quaternion &State::quat() {return quat_;}
+const Eigen::Vector3d &State::pos() const {return pos_;}
+const Eigen::Vector3d &State::vel() const {return vel_;}
+const Eigen::Vector3d &State::ang_vel() const {return ang_vel_;}
+const Quaternion &State::quat() const {return quat_;}
 
+// for backwards compatibility
 const Eigen::Vector3d &State::pos_const() const {return pos_;}
-
 const Eigen::Vector3d &State::vel_const() const {return vel_;}
-
 const Eigen::Vector3d &State::ang_vel_const() const {return ang_vel_;}
-
 const Quaternion &State::quat_const() const {return quat_;}
-
 void State::set_pos(const Eigen::Vector3d &pos) {pos_ = pos;}
-
 void State::set_vel(const Eigen::Vector3d &vel) {vel_ = vel;}
-
 void State::set_ang_vel(const Eigen::Vector3d &ang_vel) {ang_vel_ = ang_vel;}
-
 void State::set_quat(const Quaternion &quat) {quat_ = quat;}
 
 bool State::InFieldOfView(State &other, double fov_width, double fov_height) const {
@@ -127,7 +123,7 @@ Eigen::Matrix4d State::tf_matrix(bool enable_translate) {
 }
 
 std::ostream& operator<<(std::ostream& os, const State& s) {
-    const Quaternion &q = s.quat_const();
+    const Quaternion &q = s.quat();
 
     os << "(" << eigen_str(s.pos_, s.output_precision)
         << "), (" << eigen_str(s.vel_, s.output_precision)

--- a/src/math/StateWithCovariance.cpp
+++ b/src/math/StateWithCovariance.cpp
@@ -44,8 +44,8 @@ StateWithCovariance::StateWithCovariance(const scrimmage::State &state,
                                          const int &cov_num_rows,
                                          const int &cov_num_cols,
                                          const double &cov_diag) :
-    State(state.pos_const(), state.vel_const(), state.ang_vel_const(),
-          state.quat_const()),
+    State(state.pos(), state.vel(), state.ang_vel(),
+          state.quat()),
     covariance_(cov_diag * Eigen::MatrixXd::Identity(cov_num_rows, cov_num_cols)) {
 }
 

--- a/src/plugins/autonomy/Boids/Boids.cpp
+++ b/src/plugins/autonomy/Boids/Boids.cpp
@@ -98,7 +98,7 @@ void Boids::init(std::map<std::string, std::string> &params) {
 bool Boids::step_autonomy(double t, double dt) {
     // Find neighbors that are within field-of-view and within comms range
     std::vector<ID> rtree_neighbors;
-    rtree_->neighbors_in_range(state_->pos_const(), rtree_neighbors, comms_range_);
+    rtree_->neighbors_in_range(state_->pos(), rtree_neighbors, comms_range_);
 
     // Remove neighbors that are not within field of view
     for (auto it = rtree_neighbors.begin(); it != rtree_neighbors.end();

--- a/src/plugins/autonomy/TrajectoryRecordPlayback/TrajectoryRecordPlayback.cpp
+++ b/src/plugins/autonomy/TrajectoryRecordPlayback/TrajectoryRecordPlayback.cpp
@@ -104,7 +104,7 @@ void TrajectoryRecordPlayback::init(std::map<std::string,
                                        csv_.at(r, "pitch_d"),
                                        csv_.at(r, "yaw_d"));
 
-            desired_state.set_quat(quat);
+            desired_state.quat() = quat;
 
             TrajectoryPoint traj;
             traj.set_t(csv_.at(r, "t"));

--- a/src/plugins/interaction/CaptureInBoundaryInteraction/CaptureInBoundaryInteraction.cpp
+++ b/src/plugins/interaction/CaptureInBoundaryInteraction/CaptureInBoundaryInteraction.cpp
@@ -119,7 +119,7 @@ bool CaptureInBoundaryInteraction::step_entity_interaction(std::list<sc::EntityP
 
             // Find all entities within capture range of this entity
             std::vector<ID> rtree_neighbors;
-            parent_->rtree()->neighbors_in_range(ent->state()->pos_const(),
+            parent_->rtree()->neighbors_in_range(ent->state()->pos(),
                                                  rtree_neighbors,
                                                  capture_range_,
                                                  ent->id().id());

--- a/src/plugins/motion/FixedWing6DOF/FixedWing6DOF.cpp
+++ b/src/plugins/motion/FixedWing6DOF/FixedWing6DOF.cpp
@@ -351,9 +351,9 @@ bool FixedWing6DOF::step(double time, double dt) {
     Eigen::Vector3d angvel_b_e_ENU;
     angvel_b_e_ENU << angvel_b_e_bodyRef(0), -angvel_b_e_bodyRef(1), -angvel_b_e_bodyRef(2);
 
-    state_->set_pos(Eigen::Vector3d(x_[Xw], x_[Yw], x_[Zw]));
-    state_->set_vel(linear_vel_ENU);
-    state_->set_ang_vel(angvel_b_e_ENU);
+    state_->pos() = Eigen::Vector3d(x_[Xw], x_[Yw], x_[Zw]);
+    state_->vel() = linear_vel_ENU;
+    state_->ang_vel() = angvel_b_e_ENU;
 
     linear_accel_body_ = state_->quat().rotate_reverse(linear_acc_ENU);
     ang_accel_body_ = angular_acc_FLU;

--- a/src/plugins/motion/Multirotor/Multirotor.cpp
+++ b/src/plugins/motion/Multirotor/Multirotor.cpp
@@ -160,9 +160,9 @@ bool Multirotor::init(std::map<std::string, std::string> &info,
                                      std::stod(vec[2]),
                                      std::stod(vec[3])));
 
-        r.set_quat(sc::Quaternion(sc::Angles::deg2rad(std::stod(vec[4])),
+        r.quat() = sc::Quaternion(sc::Angles::deg2rad(std::stod(vec[4])),
                                   sc::Angles::deg2rad(std::stod(vec[5])),
-                                  sc::Angles::deg2rad(std::stod(vec[6]))));
+                                  sc::Angles::deg2rad(std::stod(vec[6])));
         rotors_.push_back(r);
     }
 
@@ -240,7 +240,7 @@ bool Multirotor::step(double time, double dt) {
     // Convert local coordinates to world coordinates
     state_->pos() << x_[Xw], x_[Yw], x_[Zw];
     state_->vel() << x_[Uw], x_[Vw], x_[Ww];
-    state_->set_ang_vel(state_->quat().rotate(angular_vel));
+    state_->ang_vel() = state_->quat().rotate(angular_vel);
     linear_accel_body_ = linear_acc;
     ang_accel_body_ = angular_acc;
 

--- a/src/plugins/motion/UUV6DOF/UUV6DOF.cpp
+++ b/src/plugins/motion/UUV6DOF/UUV6DOF.cpp
@@ -303,7 +303,7 @@ bool UUV6DOF::step(double time, double dt) {
     Eigen::Vector3d angvel_b_e_bodyRef = quat_body_.rotate(angular_vel);
     Eigen::Vector3d angvel_b_e_ENU;
     angvel_b_e_ENU << angvel_b_e_bodyRef[0], -angvel_b_e_bodyRef[1], -angvel_b_e_bodyRef[2];
-    state_->set_ang_vel(angvel_b_e_ENU);
+    state_->ang_vel() = angvel_b_e_ENU;
 
     state_->pos() << x_[Xw], x_[Yw], x_[Zw];
     state_->vel() << x_[Uw], x_[Vw], x_[Ww];

--- a/src/plugins/sensor/ContactBlobCamera/ContactBlobCamera.cpp
+++ b/src/plugins/sensor/ContactBlobCamera/ContactBlobCamera.cpp
@@ -138,8 +138,8 @@ bool ContactBlobCamera::step() {
     Eigen::Vector3d sensor_pos = sensor->transform()->pos() +
       parent_->state()->pos();
 
-    sensor_frame.set_quat(sensor_quat);
-    sensor_frame.set_pos(sensor_pos);
+    sensor_frame.quat() = sensor_quat;
+    sensor_frame.pos() = sensor_pos;
 
     auto msg = std::make_shared<sc::Message<ContactBlobCameraType>>();
 

--- a/src/proto_conversions/ProtoConversions.cpp
+++ b/src/proto_conversions/ProtoConversions.cpp
@@ -219,7 +219,7 @@ StatePtr proto_2_state(const scrimmage_proto::State &proto_state) {
     set(state.pos(), proto_state.position());
     set(state.vel(), proto_state.linear_velocity());
     set(state.ang_vel(), proto_state.angular_velocity());
-    state.set_quat(proto_2_quat(proto_state.orientation()));
+    state.quat() = proto_2_quat(proto_state.orientation());
     return std::make_shared<State>(state);
 }
 


### PR DESCRIPTION
Hey guys, I wanted to suggest the idea of refactoring the getters/setters for the State class (and potentially any other class where it's relevant). The current API has 3 different methods for accessing pos/vel/etc - 1 getter, 1 setter, and 1 that can do both. This has caused me confusion and led to some very time consuming bugs related to erroneously mixing return by copy and return by reference. I've also had a few instances where I made extensive use of 'pos()' as a getter, which worked fine for a time until I ran into a situation where my object was now const. Then every instance of 'pos()' had to be changed to 'pos_const()'.

I believe these headaches can all be avoided by replacing the 3 current function calls with just 1, utilizing const overloads that the compiler will resolve for you. This way the API is simpler and you never have to think about which version of the function to use, and the compiler will use the const version whenever it can and the mutable version when it needs to.

What do you guys think?