### PR TITLE
Update SimpleINS to use a timer in order to update covariance

### DIFF
--- a/include/scrimmage/plugins/autonomy/SimpleINS/SimpleINS.h
+++ b/include/scrimmage/plugins/autonomy/SimpleINS/SimpleINS.h
@@ -62,6 +62,9 @@ class SimpleINS : public scrimmage::Autonomy {
 
     Eigen::MatrixXd m_;
     bool init_m_ = true;
+
+    double surface_timer_ = 0;
+    double prev_time_ = 0;
 };
 } // namespace autonomy
 } // namespace scrimmage


### PR DESCRIPTION
- Update SimpleINS autonomy to use a time variable to reset the covariance matrix to an identity matrix rather than linearly decreasing until it got near the identity matrix.