### PR TITLE
fix vtk7 check

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,24 +189,26 @@ endif()
 ########################################################
 
 find_package(VTK QUIET NO_MODULE)
-if (${VTK_MAJOR_VERSION} LESS 7)
-    set(OPENGL_MODULE vtkRenderingOpenGL)
-else()
-    set(OPENGL_MODULE vtkRenderingOpenGL2)
-endif()
+if (${VTK_FOUND})
+    if (${VTK_MAJOR_VERSION} LESS 7)
+        set(OPENGL_MODULE vtkRenderingOpenGL)
+    else()
+        set(OPENGL_MODULE vtkRenderingOpenGL2)
+    endif()
 
-set(VTK_MODULES 
-    vtkFiltersSources
-    vtkFiltersTexture
-    vtkInteractionStyle
-    vtkIOGeometry
-    vtkIOImage
-    vtkIOLegacy
-    vtkRenderingAnnotation
-    vtkRenderingCore
-    ${OPENGL_MODULE})
+    set(VTK_MODULES 
+        vtkFiltersSources
+        vtkFiltersTexture
+        vtkInteractionStyle
+        vtkIOGeometry
+        vtkIOImage
+        vtkIOLegacy
+        vtkRenderingAnnotation
+        vtkRenderingCore
+        ${OPENGL_MODULE})
 
-find_package(VTK QUIET NO_MODULE COMPONENTS ${VTK_MODULES})
+    find_package(VTK QUIET NO_MODULE COMPONENTS ${VTK_MODULES})
+endif() 
 
 if (NOT EXTERNAL AND ${VTK_FOUND})
   message(STATUS "Found VTK Version: ${VTK_MAJOR_VERSION}.${VTK_MINOR_VERSION}.${VTK_BUILD_VERSION}")


### PR DESCRIPTION
when vtk wasn't found, cmake would throw the following

    CMake Error at CMakeLists.txt:192 (if):
      if given arguments:

        "LESS" "7"

      Unknown arguments specified