### PR TITLE
Draw ContactBlobCamera's frustum and log any detections

### DIFF
--- a/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCamera.h
+++ b/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCamera.h
@@ -54,7 +54,7 @@ class ContactBlobCamera : public scrimmage::Sensor {
     bool step() override;
 
  protected:
-    std::ofstream parameters_file_;
+    std::ofstream parameters_file_, detections_file_;
 
     std::shared_ptr<std::default_random_engine> gener_;
     std::vector<std::shared_ptr<std::normal_distribution<double>>> pos_noise_;
@@ -65,8 +65,10 @@ class ContactBlobCamera : public scrimmage::Sensor {
     void draw_object_with_bounding_box(cv::Mat frame, cv::Rect rect,
                                        Eigen::Vector2d center, double radius);
     void set_plugin_params(std::map<std::string, double> params);
+    void draw_frustum(double x_rot, double y_rot, double z_rot);
 
     // plugin parameters
+    int camera_id_;
     int img_width_;
     int img_height_;
     double max_detect_range_;
@@ -88,6 +90,9 @@ class ContactBlobCamera : public scrimmage::Sensor {
     PublisherPtr pub_;
 
     bool show_image_ = false;
+    bool show_frustum_ = false;
+
+    bool log_detections_ = false;
 };
 } // namespace sensor
 } // namespace scrimmage

--- a/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCamera.xml
+++ b/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCamera.xml
@@ -3,6 +3,8 @@
 <params>
   <library>ContactBlobCamera_plugin</library>
 
+  <camera_id>0</camera_id>
+
   <img_width>800</img_width>
   <img_height>600</img_height>
 
@@ -26,6 +28,9 @@
   <pos_noise_1>0.0 1.0</pos_noise_1> <!-- y position noise (2D image)-->
 
   <show_image>false</show_image>
+  <show_frustum>false</show_frustum>
+
+  <log_detections>false</log_detections>
 
   <!-- not used -->
   <!-- <pos_noise_2>0.0 1.0</pos_noise_2> --> <!-- z position noise -->

--- a/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCameraNoNoise.xml
+++ b/include/scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCameraNoNoise.xml
@@ -3,6 +3,8 @@
 <params>
   <library>ContactBlobCamera_plugin</library>
 
+  <camera_id>0</camera_id>
+
   <img_width>800</img_width>
   <img_height>600</img_height>
 
@@ -24,6 +26,11 @@
   <!-- noise params are defined with (mean, standard deviation) -->
   <pos_noise_0>0.0 0.0</pos_noise_0> <!-- x position noise (2D image) -->
   <pos_noise_1>0.0 0.0</pos_noise_1> <!-- y position noise (2D image)-->
+
+  <show_image>false</show_image>
+  <show_frustum>false</show_frustum>
+
+  <log_detections>false</log_detections>
 
   <!-- not used -->
   <!-- <pos_noise_2>0.0 1.0</pos_noise_2> --> <!-- z position noise -->


### PR DESCRIPTION
Added two optional features to the ContactBlobCamera sensor plugin.

show_frustum flag: visualize the frustum
log_detections flag: log the time and any detected entity ids every timestep into a sensor log in the logdir.