### PR TITLE
allow to override yaw value in SingleIntegrator plugin

### DIFF
--- a/include/scrimmage/plugins/autonomy/MotorSchemas/MotorSchemas.h
+++ b/include/scrimmage/plugins/autonomy/MotorSchemas/MotorSchemas.h
@@ -51,6 +51,7 @@ class MotorSchemas : public scrimmage::Autonomy {
 
  protected:
     bool show_shapes_;
+    bool pub_vel_vec_;
     double max_speed_;
 
     int desired_heading_idx_ = 0;

--- a/include/scrimmage/plugins/autonomy/MotorSchemas/MotorSchemas.xml
+++ b/include/scrimmage/plugins/autonomy/MotorSchemas/MotorSchemas.xml
@@ -9,9 +9,12 @@
   <state_topic_name>State</state_topic_name>
   <network_name>LocalNetwork</network_name>
 
+  <!-- Publish velocity vector instead of desired speed, altitude, and heading -->
+  <pub_vel_vec>false</pub_vel_vec>
+
   <behaviors>
     [ AvoidEntityMS gain='1.0' contacts='truth' show_shapes='true' sphere_of_influence='10' minimum_range='2' ]
     [ MoveToGoalMS gain='1.0' show_shapes='true' use_initial_heading='false' goal='100,0,0' ]
   </behaviors>
-  
+
 </params>

--- a/include/scrimmage/plugins/motion/SingleIntegrator/SingleIntegrator.h
+++ b/include/scrimmage/plugins/motion/SingleIntegrator/SingleIntegrator.h
@@ -47,9 +47,12 @@ class SingleIntegrator : public scrimmage::MotionModel {
     bool step(double t, double dt) override;
 
  protected:
+    bool override_heading_;
+
     uint8_t vel_x_idx_ = 0;
     uint8_t vel_y_idx_ = 0;
     uint8_t vel_z_idx_ = 0;
+    uint8_t desired_heading_idx_ = 0;
 };
 } // namespace motion
 } // namespace scrimmage

--- a/include/scrimmage/plugins/motion/SingleIntegrator/SingleIntegrator.xml
+++ b/include/scrimmage/plugins/motion/SingleIntegrator/SingleIntegrator.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
 <params>
-  <library>SingleIntegrator_plugin</library>  
+  <library>SingleIntegrator_plugin</library>
+  <override_heading>false</override_heading>
 </params>

--- a/src/plugins/autonomy/MotorSchemas/MotorSchemas.cpp
+++ b/src/plugins/autonomy/MotorSchemas/MotorSchemas.cpp
@@ -72,6 +72,7 @@ namespace autonomy {
 
 void MotorSchemas::init(std::map<std::string, std::string> &params) {
     show_shapes_ = sc::get("show_shapes", params, false);
+    pub_vel_vec_ = sc::get("pub_vel_vec", params, false);
     max_speed_ = sc::get<double>("max_speed", params, 21);
 
     auto max_speed_cb = [&] (const double &max_speed) {
@@ -260,17 +261,19 @@ bool MotorSchemas::step_autonomy(double t, double dt) {
     }
 
     ///////////////////////////////////////////////////////////////////////////
+    // Publish the resultant velocity vector or
     // Convert resultant vector into heading / speed / altitude command:
     ///////////////////////////////////////////////////////////////////////////
-
-    double heading = sc::Angles::angle_2pi(atan2(vel_result(1), vel_result(0)));
-    vars_.output(desired_alt_idx_, state_->pos()(2) + vel_result(2));
-    vars_.output(desired_speed_idx_, vel_result.norm());
-    vars_.output(desired_heading_idx_, heading);
-
-    vars_.output(output_vel_x_idx_, vel_result(0));
-    vars_.output(output_vel_y_idx_, vel_result(1));
-    vars_.output(output_vel_z_idx_, vel_result(2));
+    if (pub_vel_vec_) {
+        vars_.output(output_vel_x_idx_, vel_result(0));
+        vars_.output(output_vel_y_idx_, vel_result(1));
+        vars_.output(output_vel_z_idx_, vel_result(2));
+    } else {
+        double heading = sc::Angles::angle_2pi(atan2(vel_result(1), vel_result(0)));
+        vars_.output(desired_alt_idx_, state_->pos()(2) + vel_result(2));
+        vars_.output(desired_speed_idx_, vel_result.norm());
+        vars_.output(desired_heading_idx_, heading);
+    }
 
     ///////////////////////////////////////////////////////////////////////////
     // Draw important shapes

--- a/src/plugins/motion/SingleIntegrator/SingleIntegrator.cpp
+++ b/src/plugins/motion/SingleIntegrator/SingleIntegrator.cpp
@@ -52,7 +52,10 @@ bool SingleIntegrator::init(std::map<std::string, std::string> &info,
     vel_x_idx_ = vars_.declare(VariableIO::Type::velocity_x, VariableIO::Direction::In);
     vel_y_idx_ = vars_.declare(VariableIO::Type::velocity_y, VariableIO::Direction::In);
     vel_z_idx_ = vars_.declare(VariableIO::Type::velocity_z, VariableIO::Direction::In);
-    desired_heading_idx_ = vars_.declare(VariableIO::Type::desired_heading, VariableIO::Direction::In);
+
+    if (override_heading_) {
+        desired_heading_idx_ = vars_.declare(VariableIO::Type::desired_heading, VariableIO::Direction::In);
+    }
 
     auto get = [&](auto s) {return std::stod(info.at(s));};
     state_->pos() << get("x"), get("y"), get("z");


### PR DESCRIPTION
The yaw value in the SingleIntegration motion plugin is currently computed as a function of the velocity vector. However, there are uses cases where the user might want to set a specific heading that is not in the direction of movement. This commit introduces the ``override_heading`` parameter. If set to true, then the heading of the vehicle will be set to whatever value is published to the ``OverrideHeading`` topic.