### PR TITLE
Move to goal updates

### DIFF
--- a/include/scrimmage/plugins/autonomy/MoveToGoalMS/MoveToGoalMS.h
+++ b/include/scrimmage/plugins/autonomy/MoveToGoalMS/MoveToGoalMS.h
@@ -35,6 +35,7 @@
 
 #include <scrimmage/plugins/autonomy/MotorSchemas/BehaviorBase.h>
 #include <scrimmage/common/Waypoint.h>
+#include <scrimmage/common/PID.h>
 
 #include <string>
 #include <map>
@@ -52,6 +53,8 @@ class MoveToGoalMS : public scrimmage::autonomy::motor_schemas::BehaviorBase {
  protected:
     Waypoint wp_;
     Eigen::Vector3d wp_local_;
+
+    PID speed_pid_;
 };
 } // namespace motor_schemas
 } // namespace autonomy

--- a/include/scrimmage/plugins/autonomy/MoveToGoalMS/MoveToGoalMS.xml
+++ b/include/scrimmage/plugins/autonomy/MoveToGoalMS/MoveToGoalMS.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
 <params>
-  <library>MoveToGoalMS_plugin</library>  
+  <library>MoveToGoalMS_plugin</library>
+
+  <!-- PID gains -->
+  <p_gain>0.5</p_gain>
+  <i_gain>0.0</i_gain>
+  <d_gain>0.0</d_gain>
+  <integral_band>0.0</integral_band>
 </params>


### PR DESCRIPTION
The MoveToGoalMS plugin computes a velocity vector towards the waypoint goal, but it's not scaled by any speed factor. This commit adds a PID controllers that scales the magnitude of the vector as a function of the distance between the agent and the waypoint goal - i.e. the closer the agent is to the goal the smaller the magnitude of the vector. The idea is to prevent the agents from overshooting the goal.

The PID and integral band gains are part of the plugin's parameters allowing developers to easily choose the best gains for their purposes.