### PR TITLE
fix bug in calling scrimpy with no arguments

### DIFF
--- a/python/completion/scrimmage-argcomplete.bash
+++ b/python/completion/scrimmage-argcomplete.bash
@@ -2,6 +2,8 @@
 
 if type register-python-argcomplete3 > /dev/null 2>&1; then
   eval "$(register-python-argcomplete3 ros2)"
+  eval "$(register-python-argcomplete3 scrimpy)"
 elif type register-python-argcomplete > /dev/null 2>&1; then
   eval "$(register-python-argcomplete ros2)"
+  eval "$(register-python-argcomplete scrimpy)"
 fi

--- a/python/scrimmage/command/util.py
+++ b/python/scrimmage/command/util.py
@@ -3,11 +3,7 @@
 import os
 
 def env(args):
-    print('SCRIMMAGE_PLUGIN_PATH')
-    print(os.environ['SCRIMMAGE_PLUGIN_PATH'])
-    print('SCRIMMAGE_MISSION_PATH')
-    print(os.environ['SCRIMMAGE_MISSION_PATH'])
-    print('SCRIMMAGE_DATA_PATH')
-    print(os.environ['SCRIMMAGE_DATA_PATH'])
-    print('SCRIMMAGE_CONFIG_PATH')
-    print(os.environ['SCRIMMAGE_CONFIG_PATH'])
+    print('SCRIMMAGE_PLUGIN_PATH=' + os.environ['SCRIMMAGE_PLUGIN_PATH'])
+    print('SCRIMMAGE_MISSION_PATH=' + os.environ['SCRIMMAGE_MISSION_PATH'])
+    print('SCRIMMAGE_DATA_PATH=' + os.environ['SCRIMMAGE_DATA_PATH'])
+    print('SCRIMMAGE_CONFIG_PATH=' + os.environ['SCRIMMAGE_CONFIG_PATH'])

--- a/python/scrimmage/scrimpy.py
+++ b/python/scrimmage/scrimpy.py
@@ -51,6 +51,11 @@ def parse_commands():
     parser_viz.add_argument('--focal-point', type=float,
         help='camera focal point')
 
+    # print help if no arguments given
+    if len(sys.argv)==1:
+        parser.print_help(sys.stderr)
+        sys.exit(1)
+
     # for tab completion
     argcomplete.autocomplete(parser, exclude=['-h', '--help'])
     args = parser.parse_args()


### PR DESCRIPTION
- format scrimpy env consistent with env command
- add scrimpy to bash completion script