### PR TITLE
add option to limit the minimum of the z-component of the resulting v…

### DIFF
--- a/include/scrimmage/plugins/autonomy/MotorSchemas/MotorSchemas.h
+++ b/include/scrimmage/plugins/autonomy/MotorSchemas/MotorSchemas.h
@@ -54,6 +54,9 @@ class MotorSchemas : public scrimmage::Autonomy {
     bool pub_vel_vec_;
     double max_speed_;
 
+    bool add_lower_bound_to_vz_;
+    double vz_lower_bound_;
+
     int desired_heading_idx_ = 0;
     int desired_alt_idx_ = 0;
     int desired_speed_idx_ = 0;

--- a/include/scrimmage/plugins/autonomy/MotorSchemas/MotorSchemas.xml
+++ b/include/scrimmage/plugins/autonomy/MotorSchemas/MotorSchemas.xml
@@ -12,6 +12,11 @@
   <!-- Publish velocity vector instead of desired speed, altitude, and heading -->
   <pub_vel_vec>false</pub_vel_vec>
 
+  <!-- Add a lower bound on the z-component of the resulting velocity vector -->
+  <!-- to control the rate at which the vehicle approaches the ground. -->
+  <add_lower_bound_to_vz>false</add_lower_bound_to_vz>
+  <vz_lower_bound>-1.0</vz_lower_bound>
+
   <behaviors>
     [ AvoidEntityMS gain='1.0' contacts='truth' show_shapes='true' sphere_of_influence='10' minimum_range='2' ]
     [ MoveToGoalMS gain='1.0' show_shapes='true' use_initial_heading='false' goal='100,0,0' ]

--- a/src/plugins/autonomy/MotorSchemas/MotorSchemas.cpp
+++ b/src/plugins/autonomy/MotorSchemas/MotorSchemas.cpp
@@ -76,6 +76,9 @@ void MotorSchemas::init(std::map<std::string, std::string> &params) {
     pub_vel_vec_ = sc::get("pub_vel_vec", params, false);
     max_speed_ = sc::get<double>("max_speed", params, 21);
 
+    add_lower_bound_to_vz_ = sc::get("add_lower_bound_to_vz", params, false);
+    vz_lower_bound_ = sc::get<double>("vz_lower_bound", params, -1.0);
+
     auto max_speed_cb = [&] (const double &max_speed) {
         cout << "MotorSchemas Max speed set: " << max_speed << endl;
     };
@@ -266,6 +269,10 @@ bool MotorSchemas::step_autonomy(double t, double dt) {
     // Convert resultant vector into heading / speed / altitude command:
     ///////////////////////////////////////////////////////////////////////////
     if (pub_vel_vec_) {
+        // Add a lower bound on the z-component of the resulting velocity vector
+        if (add_lower_bound_to_vz_) {
+            vel_result(2) = std::max(vz_lower_bound_, vel_result(2));
+        }
         vars_.output(output_vel_x_idx_, vel_result(0));
         vars_.output(output_vel_y_idx_, vel_result(1));
         vars_.output(output_vel_z_idx_, vel_result(2));


### PR DESCRIPTION
By default, the resulting velocity vector outputted by the MotorSchemas plugin is passed to the controller. This pull request introduces the option to add a lower bound on the z-component of the resulting velocity vector. The idea is to (optionally) cap the rate at which flying vehicles move towards the ground.

Adding the lower bound is defaulted to false so developers would be required to set to true in their mission files if so desired.