### PR TITLE
Send AirSim Data to ROS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -255,7 +255,7 @@ install(TARGETS scrimmage-boost EXPORT ${PROJECT_NAME}-targets)
 ########################################################
 # Find OpenCV
 ########################################################
-find_package(OpenCV QUIET)
+find_package(OpenCV 3.0.0)
 if (OpenCV_FOUND)
   add_library(scrimmage-opencv INTERFACE)
   target_include_directories(scrimmage-opencv INTERFACE ${OpenCV_INCLUDE_DIRS})
@@ -274,7 +274,7 @@ set(ROS_VERSION "kinetic" CACHE STRING "The ROS distribution version.")
 if (BUILD_ROS_PLUGINS)
   set(CMAKE_PREFIX_PATH ${CMAKE_PREFIX_PATH} /opt/ros/${ROS_VERSION}/)
   find_package(catkin REQUIRED COMPONENTS roscpp sensor_msgs std_msgs
-    geometry_msgs nav_msgs tf image_transport cv_bridge)
+    geometry_msgs nav_msgs tf image_transport cv_bridge tf2_ros tf2)
   if (catkin_FOUND)
     include_directories(${catkin_INCLUDE_DIRS})
   endif()

--- a/ci/dockerfiles/ubuntu-16.04
+++ b/ci/dockerfiles/ubuntu-16.04
@@ -24,6 +24,8 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources
     ruby-full \
     build-essential \
     zlib1g-dev \
+    ros-kinetic-opencv3 \
+    ros-kinetic-tf2 \
  && add-apt-repository ppa:kevin-demarco/scrimmage \
  && apt-get update \
  && apt-get install -y scrimmage-dependencies \

--- a/docs/source/tutorials/airsim-plugin.rst
+++ b/docs/source/tutorials/airsim-plugin.rst
@@ -180,9 +180,9 @@ Linux
 *****
 
 Ubuntu 18.04 is recommended. If you haven't already installed SCRIMMAGE on your Linux machine, do so by following
-directions here:(https://github.com/gtri/scrimmage). Also make sure that OpenCV is installed on your system. You will
-need to pull the code for AirSim v1.2.2 and build the libstdc++ version of AirSim on your Linux
-computer. Then build SCRIMMAGE with the AirSim SCRIMMAGE plugin.
+directions here:(https://github.com/gtri/scrimmage). Also make sure that an OpenCV above version 3.0.0 is installed on
+your Linux system, version 3.4.0+ is recommended. You will need to pull the code for AirSim v1.2.2 and build the
+libstdc++ version of AirSim on your Linux computer. Then build SCRIMMAGE with the AirSim SCRIMMAGE plugin.
 
 #. **Build the libstdc++ version of AirSim (which will be loaded into SCRIMMAGE)**
 
@@ -338,19 +338,54 @@ To save the images and quaternion pose CSV from the simulation for later process
 set save_airsim_data="true" in the scrimmage mission file quad-airsim-ex1.xml. The Scrimmage Logs directory should be
 located in ~/.scrimmage/logs on the Linux side.
 
+To retrieve Image data from the simulation set get_image_data="true" in the scrimmage mission file quad-airsim-ex1.xml.
+Camera image types can be configured in scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml
+
 To retrieve LIDAR data from the simulation set get_lidar_data="true" in the scrimmage mission file quad-airsim-ex1.xml.
-LIDAR settings can be changed in the settings.json file on the Windows side located in Documents\AirSim.
+LIDAR and image settings can be changed in the settings.json file on the Windows side located in Documents\\AirSim.
 See (https://github.com/microsoft/AirSim/blob/master/docs/lidar.md) for more details.
-Variable DrawDebugPoints in the settings.json file will show the LIDAR pointcloud in the simulation, but it will also
-appear in the saved images so by default it is set to false.
+Lidar variable DrawDebugPoints in the settings.json file will show the LIDAR pointcloud in the simulation as seen in the
+image below, however it will also appear in the saved images so by default it is set to false.
 
 .. image:: ../images/LIDAR_DrawDebugPoints.png
     :width: 600
 
+Publish Images and LIDAR data to ROS
+************************************
+
+To publish AirSim data to ROS you must build scrimmage with -DBUILD_ROS_PLUGINS=ON, example below. Uncomment the
+"<autonomy>ROSAirSim</autonomy>" tag in the scrimmage mission file quad-airsim-ex1.xml. To publish image or lidar data
+set "pub_image/lidar_data" to true within the ROSAirSim tag, however be sure to have "get_image/lidar_data" set to true
+in the AirSimSensor tag above in order to receive the data. Setting "show_camera_images" to true will display images
+from each camera type in OpenCV windows. By default images are shown using the ""<autonomy>Straight</autonomy>" tag in
+quad-airsim-ex1.xml, this only needs to be specified once.
+
+   .. code-block:: bash
+
+      # Go into Scrimmage
+      cd /path/to/scrimmage/
+      # Delete build directory
+      rm -rf build/ && mkdir build/ && cd build/
+      # Config CMake to build SCRIMMAGE ROS Plugins
+      cmake .. -DAIRSIM_ROOT_SEARCH=/home/nrakoski3/scrimmage/AirSim/ -DROS_VERSION=melodic -DBUILD_ROS_PLUGINS=ON
+      # Build
+      make -j7
+      # Open a second Terminal window and start ROS
+      roscore
+      # Run from original Terminal window
+      cd .. && scrimmage ./missions/quad-airsim-ex1.xml
+      # Start RVIZ in a third Terminal window to visualize LIDAR data
+      rviz ./scrimmage/include/scrimmage/plugins/autonomy/ROSAirSim/lidar.rviz
+
+Run with Multiple Quadcopters
+*****************************
+
+COMING SOON
+
 Add "Asset" Environments
 **************************
 
-AirSim offers different environments that can be played but not edited for every release version called **"Assets"**.
+AirSim offers photo-realistic environments that can be played(not edited) for every release version called **"Assets"**.
 They can be found here: (https://github.com/Microsoft/AirSim/releases). Download one of the Asset ZIP files under your
 AirSim version (here we used LandscapeMountains under v1.2.2) onto the Windows machine and place in the
 directory: c:/AirSim/Unreal/Environments/. Assets for newer versions of AirSim will not work with older versions of

--- a/include/scrimmage/parse/ParseUtils.h
+++ b/include/scrimmage/parse/ParseUtils.h
@@ -116,7 +116,7 @@ bool str2container(const std::string &str, const std::string &delims,
 }
 
 template <typename T>
-[[deprecated("str2vec is deprecated, use str2container instead")]]
+// [[deprecated("str2vec is deprecated, use str2container instead")]]
 std::vector<T> str2vec(const std::string &str, const std::string &delims) {
     std::vector<T> out;
     std::vector<std::string> tokens;
@@ -131,7 +131,7 @@ std::vector<T> str2vec(const std::string &str, const std::string &delims) {
 }
 
 template <typename T>
-[[deprecated("str2vec is deprecated, use str2container instead")]]
+// [[deprecated("str2vec is deprecated, use str2container instead")]]
 bool str2vec(const std::string &str, const std::string &delims,
              std::vector<T> &vec, int size = -1) {
     std::vector<T> tmp_vec;

--- a/include/scrimmage/plugins/autonomy/ROSAirSim/ROSAirSim.h
+++ b/include/scrimmage/plugins/autonomy/ROSAirSim/ROSAirSim.h
@@ -37,14 +37,28 @@
 #include <ros/ros.h>
 #include <image_transport/image_transport.h>
 #include <cv_bridge/cv_bridge.h>
+#include <sensor_msgs/PointCloud2.h>
+#include <sensor_msgs/Image.h>
+// #include <tf/transform_broadcaster.h>
+// #include <tf/transform_datatypes.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+#include <tf2_ros/transform_broadcaster.h>
+#include <tf2/LinearMath/Quaternion.h>
+#include <geometry_msgs/Twist.h>
 
 #include <string>
 #include <map>
 #include <memory>
 #include <vector>
 
+#include "common/AirSimSettings.hpp"
+
+typedef msr::airlib::AirSimSettings::LidarSetting LidarSetting;
+
 namespace scrimmage {
 namespace autonomy {
+
 class ROSAirSim : public scrimmage::Autonomy {
  public:
     void init(std::map<std::string, std::string> &params) override;
@@ -52,12 +66,17 @@ class ROSAirSim : public scrimmage::Autonomy {
 
  protected:
     bool show_camera_images_ = false;
-
+    bool pub_image_data_ = true;
+    bool pub_lidar_data_ = true;
 
     std::shared_ptr<ros::NodeHandle> nh_;
     std::shared_ptr<image_transport::ImageTransport> it_;
-
     std::vector<image_transport::Publisher> img_publishers_;
+
+    ros::Publisher base_scan_pub_;
+    std::shared_ptr<tf2_ros::TransformBroadcaster> laser_broadcaster_;
+    std::vector<geometry_msgs::TransformStamped> tf_msg_vec_;
+    geometry_msgs::TransformStamped laser_trans_;
 
     std::string ros_namespace_;
 };

--- a/include/scrimmage/plugins/autonomy/ROSAirSim/ROSAirSim.xml
+++ b/include/scrimmage/plugins/autonomy/ROSAirSim/ROSAirSim.xml
@@ -2,5 +2,7 @@
 <?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
 <params>
   <library>ROSAirSim_plugin</library>
-  <show_camera_images>true</show_camera_images>
+  <show_camera_images>false</show_camera_images>
+  <pub_image_data>true</pub_image_data>
+  <pub_lidar_data>true</pub_lidar_data>
 </params>

--- a/include/scrimmage/plugins/autonomy/ROSAirSim/lidar.rviz
+++ b/include/scrimmage/plugins/autonomy/ROSAirSim/lidar.rviz
@@ -1,0 +1,152 @@
+Panels:
+  - Class: rviz/Displays
+    Help Height: 78
+    Name: Displays
+    Property Tree Widget:
+      Expanded:
+        - /Global Options1
+        - /Status1
+        - /PointCloud21
+        - /PointCloud21/Status1
+      Splitter Ratio: 0.5
+    Tree Height: 549
+  - Class: rviz/Selection
+    Name: Selection
+  - Class: rviz/Tool Properties
+    Expanded:
+      - /2D Pose Estimate1
+      - /2D Nav Goal1
+      - /Publish Point1
+    Name: Tool Properties
+    Splitter Ratio: 0.5886790156364441
+  - Class: rviz/Views
+    Expanded:
+      - /Current View1
+    Name: Views
+    Splitter Ratio: 0.5
+  - Class: rviz/Time
+    Experimental: false
+    Name: Time
+    SyncMode: 0
+    SyncSource: ""
+Preferences:
+  PromptSaveOnExit: true
+Toolbars:
+  toolButtonStyle: 2
+Visualization Manager:
+  Class: ""
+  Displays:
+    - Alpha: 0.5
+      Cell Size: 1
+      Class: rviz/Grid
+      Color: 160; 160; 164
+      Enabled: true
+      Line Style:
+        Line Width: 0.029999999329447746
+        Value: Lines
+      Name: Grid
+      Normal Cell Count: 0
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Plane: XY
+      Plane Cell Count: 10
+      Reference Frame: <Fixed Frame>
+      Value: true
+    - Alpha: 1
+      Autocompute Intensity Bounds: true
+      Autocompute Value Bounds:
+        Max Value: 10
+        Min Value: -10
+        Value: true
+      Axis: Z
+      Channel Name: intensity
+      Class: rviz/PointCloud2
+      Color: 255; 255; 255
+      Color Transformer: ""
+      Decay Time: 0
+      Enabled: true
+      Invert Rainbow: false
+      Max Color: 255; 255; 255
+      Max Intensity: 4096
+      Min Color: 0; 0; 0
+      Min Intensity: 0
+      Name: PointCloud2
+      Position Transformer: ""
+      Queue Size: 10
+      Selectable: true
+      Size (Pixels): 3
+      Size (m): 0.009999999776482582
+      Style: Flat Squares
+      Topic: /robot1/base_scan
+      Unreliable: false
+      Use Fixed Frame: true
+      Use rainbow: true
+      Value: true
+  Enabled: true
+  Global Options:
+    Background Color: 48; 48; 48
+    Default Light: true
+    Fixed Frame: map
+    Frame Rate: 30
+  Name: root
+  Tools:
+    - Class: rviz/Interact
+      Hide Inactive Objects: true
+    - Class: rviz/MoveCamera
+    - Class: rviz/Select
+    - Class: rviz/FocusCamera
+    - Class: rviz/Measure
+    - Class: rviz/SetInitialPose
+      Theta std deviation: 0.2617993950843811
+      Topic: /initialpose
+      X std deviation: 0.5
+      Y std deviation: 0.5
+    - Class: rviz/SetGoal
+      Topic: /move_base_simple/goal
+    - Class: rviz/PublishPoint
+      Single click: true
+      Topic: /clicked_point
+  Value: true
+  Views:
+    Current:
+      Class: rviz/Orbit
+      Distance: 10
+      Enable Stereo Rendering:
+        Stereo Eye Separation: 0.05999999865889549
+        Stereo Focal Distance: 1
+        Swap Stereo Eyes: false
+        Value: false
+      Focal Point:
+        X: 0
+        Y: 0
+        Z: 0
+      Focal Shape Fixed Size: true
+      Focal Shape Size: 0.05000000074505806
+      Invert Z Axis: false
+      Name: Current View
+      Near Clip Distance: 0.009999999776482582
+      Pitch: 0.7903980016708374
+      Target Frame: <Fixed Frame>
+      Value: Orbit (rviz)
+      Yaw: 0.785398006439209
+    Saved: ~
+Window Geometry:
+  Displays:
+    collapsed: false
+  Height: 846
+  Hide Left Dock: false
+  Hide Right Dock: false
+  QMainWindow State: 000000ff00000000fd00000004000000000000026c000002b0fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073010000003d000002b0000000c900fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f000002b0fc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073010000003d000002b0000000a400fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000066b0000003efc0100000002fb0000000800540069006d006501000000000000066b000002eb00fffffffb0000000800540069006d00650100000000000004500000000000000000000002e4000002b000000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+  Selection:
+    collapsed: false
+  Time:
+    collapsed: false
+  Tool Properties:
+    collapsed: false
+  Views:
+    collapsed: false
+  Width: 1643
+  X: 2083
+  Y: 47

--- a/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h
+++ b/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h
@@ -66,27 +66,37 @@ class CameraConfig {
         msr::airlib::ImageCaptureBase::ImageType img_type =
             msr::airlib::ImageCaptureBase::ImageType::Scene;
 
-        std::string name = "none";
-        int number = 0;
+        std::string cam_name = "none";
+        int cam_number = 0;
+        std::string img_type_name = "none";
+        int img_type_number = 0;
         int height = 144; // 288
         int width = 256;  // 512
-        std::string img_type_name = "none";
+
 
         friend std::ostream& operator<<(std::ostream& os,
                                         const CameraConfig& c) {
-            os << "Name=" << c.name;
-            os << ", Number=" << c.number;
+            os << "Camera_Number=" << c.cam_number;
+            os << ", Camera_Name=" << c.cam_name;
+            os << ", Image_Type_Num=" << c.img_type_number;
+            os << ", Image_Type_Name=" << c.img_type_name;
             os << ", Height=" << c.height;
             os << ", Width=" << c.width;
-            os << ", Image_Type=" << c.img_type_name;
             return os;
         }
 };
 
-class AirSimSensorType {
+class AirSimImageType {
  public:
     cv::Mat img;
     CameraConfig camera_config;
+    int frame_num = 0;
+};
+
+class AirSimLidarType {
+ public:
+    msr::airlib::LidarData lidar_data;
+    int frame_num = 0;
 };
 
 class AirSimSensor : public scrimmage::Sensor {
@@ -99,7 +109,8 @@ class AirSimSensor : public scrimmage::Sensor {
  protected:
     std::thread request_images_thread_;
     void request_images();
-    scrimmage::MessagePtr<std::vector<AirSimSensorType>> img_msg_ = nullptr;
+    scrimmage::MessagePtr<std::vector<AirSimImageType>> img_msg_ = nullptr;
+    scrimmage::MessagePtr<AirSimLidarType> lidar_msg_ = nullptr;
     std::mutex img_msg_mutex_;
 
     bool running_ = true;
@@ -113,12 +124,16 @@ class AirSimSensor : public scrimmage::Sensor {
     float airsim_timeout_s_;
     std::list<CameraConfig> cam_configs_;
     scrimmage::Angles enu_to_ned_yaw_;
-    PublisherPtr pub_;
 
-    bool save_images(MessagePtr<std::vector<AirSimSensorType>>& msg, StatePtr& state);
+    PublisherPtr img_pub_;
+    PublisherPtr lidar_pub_;
 
-    bool save_airsim_data_ = false;
-    bool get_lidar_data_ = false;
+    bool save_data(MessagePtr<std::vector<AirSimImageType>>& im_msg, StatePtr& state);
+
+    bool save_airsim_data_ = true;
+    bool get_image_data_ = true;
+    bool get_lidar_data_ = true;
+
     int airsim_frame_num_ = 0;
     scrimmage::CSV csv;
 

--- a/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml
+++ b/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml
@@ -8,34 +8,29 @@
   <airsim_timeout_s>60</airsim_timeout_s>
 
   <!--
-      [CameraID=forward=0 ImageType CameraNumber=ImageTypeValue Width Height]
+      [CameraNumber=Forward=0 ImageTypeName=Scene ImageTypeNumber=0 Width=256 Height=144]
+
+      AirSim Camera Types:
+      Front_Center=0, Front_Right=1, Front_Left=2, Bottom_Center=3, Back_Center=4
 
       AirSim Image Types:
-      Scene, DepthPlanner, DepthPerspective, DepthVis, DisparityNormalized,
-      Segmentation, SurfaceNormals
-      Example: [Forward=0 Scene 0 256 144] [Downward Scene 3 256 144]
+      Scene=0, DepthPlanner=1, DepthPerspective=2, DepthVis=3, DisparityNormalized=4,
+      Segmentation=5, SurfaceNormals=6, Infrared=7
+
+      Example: [0 Scene 0 256 144]
   -->
   <camera_config>
     [0 Scene 0 256 144]
     [0 DepthPerspective 2 256 144]
     [0 Segmentation 5 256 144]
+    [0 Infrared 7 256 144]
   </camera_config>
 
-  <!--
-      <camera_config>
-    [SceneForward Scene 0 256 144]
-    [SceneDownward Scene 3 256 144]
-    [DepthPlanner DepthPlanner 0 256 144]
-    [DepthPerspective DepthPerspective 0 256 144]
-    [DepthViz DepthVis 0 256 144]
-    [DisparityNormalized DisparityNormalized 0 256 144]
-    [Segmentation Segmentation 0 256 144]
-    [SurfaceNormals SurfaceNormals 0 256 144]
-    </camera_config>
-    -->
   <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs-->
-  <save_airsim_data>false</save_airsim_data>
-  <!-- get_lidar_data requests lidar data from AirSim-->
-  <get_lidar_data>false</get_lidar_data>
+  <save_airsim_data>true</save_airsim_data>
+  <!-- get_image_data requests image data from AirSim -->
+  <get_image_data>true</get_image_data>
+  <!-- get_lidar_data requests lidar data from AirSim -->
+  <get_lidar_data>true</get_lidar_data>
 
 </params>

--- a/include/scrimmage/plugins/sensor/AirSimSensor/settings.json
+++ b/include/scrimmage/plugins/sensor/AirSimSensor/settings.json
@@ -11,7 +11,8 @@
     "Cameras": [
 		  { "CameraID": 0, "ImageType": 0, "PixelsAsFloat": false, "Compress": false },
 		  { "CameraID": 0, "ImageType": 2, "PixelsAsFloat": true, "Compress": false },
-		  { "CameraID": 0, "ImageType": 5, "PixelsAsFloat": false, "Compress": false }
+		  { "CameraID": 0, "ImageType": 5, "PixelsAsFloat": false, "Compress": false },
+          { "CameraID": 0, "ImageType": 7, "PixelsAsFloat": false, "Compress": false }
 	  ]
   },
   "CameraDefaults": {
@@ -38,6 +39,16 @@
       },
 	  {
         "ImageType": 5,
+        "Width": 256,
+        "Height": 144,
+        "FOV_Degrees": 90,
+        "AutoExposureSpeed": 100,
+        "AutoExposureBias": 0,
+        "AutoExposureMaxBrightness": 0.68,
+        "AutoExposureMinBrightness": 0.03
+      },
+      {
+        "ImageType": 7,
         "Width": 256,
         "Height": 144,
         "FOV_Degrees": 90,

--- a/missions/quad-airsim-ex1.xml
+++ b/missions/quad-airsim-ex1.xml
@@ -57,12 +57,26 @@
     <z>10</z> <!-- LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
     <heading>0</heading>
 
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
     <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
     <!-- get_lidar_data requests lidar data from AirSim -->
     <sensor airsim_ip="10.108.21.246"
-            save_airsim_data="false"
-            get_lidar_data="false">AirSimSensor</sensor>
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true">AirSimSensor</sensor>
 
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
     <autonomy show_camera_images="true">Straight</autonomy>
 
     <motion_model motion_model_sets_yaw="false"

--- a/src/plugins/autonomy/ROSAirSim/ROSAirSim.cpp
+++ b/src/plugins/autonomy/ROSAirSim/ROSAirSim.cpp
@@ -29,9 +29,7 @@
  * A Long description goes here.
  *
  */
-
 #include <scrimmage/plugins/autonomy/ROSAirSim/ROSAirSim.h>
-
 #include <scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h>
 #include <scrimmage/plugin_manager/RegisterPlugin.h>
 #include <scrimmage/entity/Entity.h>
@@ -44,20 +42,32 @@
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
 
+#include <boost/algorithm/string.hpp>
+
 using std::cout;
 using std::endl;
 
 namespace sc = scrimmage;
 
-REGISTER_PLUGIN(scrimmage::Autonomy,
-                scrimmage::autonomy::ROSAirSim,
-                ROSAirSim_plugin)
+REGISTER_PLUGIN(scrimmage::Autonomy, scrimmage::autonomy::ROSAirSim, ROSAirSim_plugin)
 
 namespace scrimmage {
 namespace autonomy {
 
 void ROSAirSim::init(std::map<std::string, std::string> &params) {
-    show_camera_images_ = scrimmage::get<bool>("show_camera_images", params, true);
+    show_camera_images_ = scrimmage::get<bool>("show_camera_images", params, "false");
+    pub_image_data_ = sc::get<bool>("pub_image_data", params, "true");
+    pub_lidar_data_ = sc::get<bool>("pub_lidar_data", params, "true");
+    cout << " " << endl;
+    if (pub_image_data_) {
+        cout << "Publishing AirSim images to ROS." << endl;
+    }
+    if (pub_lidar_data_) {
+        cout << "Publishing AirSim LIDAR data to ROS." << endl;
+    }
+    if (show_camera_images_) {
+        cout << "ROSAirSim: Showing camera images in OpenCV windows." << endl;
+    }
 
     // initialize ros
     if (!ros::isInitialized()) {
@@ -71,36 +81,175 @@ void ROSAirSim::init(std::map<std::string, std::string> &params) {
     ros_namespace_ = sc::get<std::string>("ros_namespace_prefix", params, "robot");
     ros_namespace_ += std::to_string(parent_->id().id());
 
+    // setup image transport node
     // image_transport::ImageTransport it(nh_);
     it_ = std::make_shared<image_transport::ImageTransport>(*nh_);
 
-    // airsim image callback
-    auto airsim_cb = [&](auto &msg) {
-        for (sc::sensor::AirSimSensorType a : msg->data) {
-            // look for existing publisher on the named topic
-            std::string topic_name = ros_namespace_ + "/" + a.camera_config.name;
-            bool published = false;
-            for (auto pub : img_publishers_) {
-                if (pub.getTopic() == topic_name) {
-                    sensor_msgs::ImagePtr msg = cv_bridge::CvImage(std_msgs::Header(), "bgr8", a.img).toImageMsg();
-                    pub.publish(msg);
-                    published = true;
-                }
+    // airsim lidar callback
+    auto airsim_lidar_cb = [&](auto &msg) {
+        if (pub_lidar_data_) {
+            ros::Time ros_time = ros::Time::now();
+            // Get LIDAR data, lidar data corresponds to each group of image types requested
+            std::string laser_topic_name = "/" + ros_namespace_ + "/base_scan";
+            if (base_scan_pub_.getTopic() != laser_topic_name) {
+                // cout << "Do this once." << endl;
+                base_scan_pub_ = nh_->advertise<sensor_msgs::PointCloud2>(ros_namespace_ + "/base_scan", 1);
             }
-            // if it doesn't exist, create it.
-            // TODO: you lose a frame in this construction
-            if (false == published) {
-                img_publishers_.push_back(it_->advertise(topic_name, 1));
-            }
+            auto lidar_data = msg->data.lidar_data;
 
-            // draw image
-            if (show_camera_images_) {
-                cv::imshow(a.camera_config.name.c_str(), a.img);
-                cv::waitKey(1);
+            // Create PointCloud2 message
+            //////////////////////////////////////////////////////////////////////
+            sensor_msgs::PointCloud2 lidar_msg;
+            lidar_msg.header.stamp = ros_time;
+            lidar_msg.header.frame_id = ros_namespace_ + "/base_laser";
+            if (lidar_data.point_cloud.size() > 3) {
+                lidar_msg.height = 1;
+                lidar_msg.width = lidar_data.point_cloud.size() / 3;
+
+                lidar_msg.fields.resize(3);
+                lidar_msg.fields[0].name = "x";
+                lidar_msg.fields[1].name = "y";
+                lidar_msg.fields[2].name = "z";
+                int offset = 0;
+
+                for (size_t d = 0; d < lidar_msg.fields.size(); ++d, offset += 4) {
+                    lidar_msg.fields[d].offset = offset;
+                    lidar_msg.fields[d].datatype = sensor_msgs::PointField::FLOAT32;
+                    lidar_msg.fields[d].count  = 1;
+                }
+
+                lidar_msg.is_bigendian = false;
+                lidar_msg.point_step = offset; // 4 * num fields
+                lidar_msg.row_step = lidar_msg.point_step * lidar_msg.width;
+
+                lidar_msg.is_dense = true;
+                std::vector<float> data_std = lidar_data.point_cloud;
+
+                const unsigned char* bytes = reinterpret_cast<const unsigned char*>(&data_std[0]);
+                vector<unsigned char> lidar_msg_data(bytes, bytes + sizeof(float) * data_std.size());
+                lidar_msg.data = std::move(lidar_msg_data);
             }
+            base_scan_pub_.publish(lidar_msg);
+            //////////////////////////////////////////////////////////////////////
+
+            // Create TF: Transformation Broadcaster for LIDAR
+            //////////////////////////////////////////////////////////////////////
+            laser_broadcaster_ = std::make_shared<tf2_ros::TransformBroadcaster>();
+
+            // TODO: Pull these values from the settings.json file on the windows side.
+            LidarSetting lidar_setting;
+            lidar_setting.position.x() = 0.0;
+            lidar_setting.position.y() = 0.0;
+            lidar_setting.position.z() = -1.0;
+            lidar_setting.rotation.roll = 0.0;
+            lidar_setting.rotation.pitch = 0.0;
+            lidar_setting.rotation.yaw = 0.0;
+
+            laser_trans_.header.frame_id = ros_namespace_ + "/base_link";
+            laser_trans_.child_frame_id = ros_namespace_ + "/base_laser";
+            laser_trans_.transform.translation.x = lidar_setting.position.x();
+            laser_trans_.transform.translation.y = lidar_setting.position.y();
+            laser_trans_.transform.translation.z = lidar_setting.position.z();
+
+            // tf::Quaternion laser_quat;
+            // geometry_msgs::Quaternion laser_quat = tf::createQuaternionMsgFromYaw(lidar_setting.rotation.yaw);
+            tf2::Quaternion laser_quat;
+            laser_quat.setRPY(lidar_setting.rotation.roll, lidar_setting.rotation.pitch, lidar_setting.rotation.yaw);
+            // laser_trans_.transform.rotation = laser_quat;
+            laser_trans_.transform.rotation.x = laser_quat.x();
+            laser_trans_.transform.rotation.y = laser_quat.y();
+            laser_trans_.transform.rotation.z = laser_quat.z();
+            laser_trans_.transform.rotation.w = laser_quat.w();
+            // Send Transform
+            laser_trans_.header.stamp = ros_time;
+            tf_msg_vec_.push_back(laser_trans_);
+            laser_broadcaster_->sendTransform(tf_msg_vec_);
+            //////////////////////////////////////////////////////////////////////
         }
     };
-    subscribe<std::vector<sensor::AirSimSensorType>>("LocalNetwork", "AirSim", airsim_cb);
+    // airsim image callback
+    auto airsim_image_cb = [&](auto &msg) {
+        if (pub_image_data_) {
+            // Create the ROSmsg header for the soon to be published messages
+            std_msgs::Header header; // empty header
+            header.seq = msg->data[0].frame_num; // AirSim defined counter
+            header.stamp = ros::Time::now(); // time
+
+            // For each AirSim msg of (camera_config, img) in msg vector
+            for (sc::sensor::AirSimImageType a : msg->data) {
+                sensor_msgs::ImagePtr img_msg;
+
+                // Create the topic name
+                std::string camera_name = boost::algorithm::to_lower_copy(a.camera_config.cam_name);
+                std::string image_type_name = boost::algorithm::to_lower_copy(a.camera_config.img_type_name);
+                std::string topic_name = "/" + ros_namespace_ + "/" + camera_name + "_" + image_type_name;
+                std::string topic_name_pub = ros_namespace_ + "/" + camera_name + "_" + image_type_name;
+                // cout << topic_name << endl;
+                // cout << "img size:" << a.img.size() << endl;
+                // cout << "img channels:" << a.img.channels() << endl;
+
+                // Check if topic publisher exists for each AirSim msg type, if so publish
+                bool published = false;
+                for (auto pub : img_publishers_) {
+
+                    // If the topic publisher exists, publish to topic
+                    if (pub.getTopic() == topic_name) {
+                        published = true;
+                        if (topic_name == "/robot1/front_center_depthperspective" || topic_name == "/robot1/front_center_depthplanner") {
+                            img_msg = cv_bridge::CvImage(header, "", a.img).toImageMsg();
+                        } else {
+                            img_msg = cv_bridge::CvImage(header, "rgb8", a.img).toImageMsg();
+                        }
+                        pub.publish(img_msg);
+                    }
+                }
+
+                // If it gets through the above for loop with published=false then the topic doesn't exist
+                if (published == false) {
+                    // cout << "Do this once." << endl;
+                    // cout << topic_name << endl;
+
+                    // create new publisher for the new topic
+                    img_publishers_.push_back(it_->advertise(topic_name_pub, 1));
+
+                    // Publish message so we don't skip frame
+                    if (topic_name == "/robot1/front_center_depthperspective" || topic_name == "/robot1/front_center_depthplanner") {
+                        img_msg = cv_bridge::CvImage(header, "", a.img).toImageMsg();
+                    } else {
+                        img_msg = cv_bridge::CvImage(header, "rgb8", a.img).toImageMsg();
+                    }
+                    // publish using last publisher created
+                    img_publishers_.back().publish(img_msg);
+
+                    // topic name should print twice, checking that no weird threading error is occurring
+                    // cout << topic_name << endl;
+                    // cout << img_publishers_.back().getTopic() << endl;
+                }
+                // draw image
+                if (show_camera_images_) {
+                    std::string window_name = a.camera_config.cam_name + "_" + a.camera_config.img_type_name;
+                    if (a.camera_config.img_type_name == "DepthPerspective" || a.camera_config.img_type_name == "DepthPlanner") {
+                        cv::Mat tempImage;
+                        a.img.convertTo(tempImage, CV_32FC1, 1.f/255);
+                        // cv::normalize(a.img, tempImage, 0, 1, cv::NORM_MINMAX);
+                        // cout << tempImage << endl;
+                        cv::imshow(window_name, tempImage);
+                    } else {
+                        // other image types are int 0-255.
+                        cv::imshow(window_name, a.img);
+                    }
+                    cv::waitKey(1);
+                }
+            }
+            // TODO: Odom transform broadcaster for camera position on drone.
+        }
+    };
+    if (pub_lidar_data_) {
+        subscribe<sensor::AirSimLidarType>("LocalNetwork", "AirSimLidar", airsim_lidar_cb);
+    }
+    if (pub_image_data_) {
+        subscribe<std::vector<sensor::AirSimImageType>>("LocalNetwork", "AirSimImages", airsim_image_cb);
+    }
 }
 
 bool ROSAirSim::step_autonomy(double t, double dt) {

--- a/src/plugins/autonomy/Straight/Straight.cpp
+++ b/src/plugins/autonomy/Straight/Straight.cpp
@@ -52,6 +52,7 @@
 #include <scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCameraType.h>
 #include <opencv2/core/core.hpp>
 #include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
 #endif
 
 #if ENABLE_AIRSIM == 1
@@ -153,29 +154,17 @@ void Straight::init(std::map<std::string, std::string> &params) {
 
 #if (ENABLE_OPENCV == 1 && ENABLE_AIRSIM == 1)
     auto airsim_cb = [&](auto &msg) {
-        for (sc::sensor::AirSimSensorType a : msg->data) {
+        for (sc::sensor::AirSimImageType a : msg->data) {
             if (show_camera_images_) {
                 // Get Camera Name
-                std::string window_name;
-                if (a.camera_config.name == "0") {
-                    window_name = "Front_Center_" + a.camera_config.img_type_name;
-                } else if (a.camera_config.name == "1") {
-                    window_name = "Front_Right_" + a.camera_config.img_type_name;
-                } else if (a.camera_config.name == "2") {
-                    window_name = "Front_Left_" + a.camera_config.img_type_name;
-                } else if (a.camera_config.name == "3") {
-                    window_name = "Bottom_Center_" + a.camera_config.img_type_name;
-                } else if (a.camera_config.name == "4") {
-                    window_name = "Back_Center_" + a.camera_config.img_type_name;
-                } else {
-                    cout << "Error: Unknown camera type: " << a.camera_config.name << endl;
-                    window_name = "Unknown_" + a.camera_config.img_type_name;
-                }
-
+                std::string window_name = a.camera_config.cam_name + "_" + a.camera_config.img_type_name;
                 // for depth images CV imshow expects grayscale image values to be between 0 and 1.
                 if (a.camera_config.img_type_name == "DepthPerspective" || a.camera_config.img_type_name == "DepthPlanner") {
+                    // Worked before building with ROS
                     cv::Mat tempImage;
                     a.img.convertTo(tempImage, CV_32FC1, 1.f/255);
+                    // cv::normalize(a.img, tempImage, 0, 1, cv::NORM_MINMAX);
+                    // cout << tempImage << endl;
                     cv::imshow(window_name, tempImage);
                 } else {
                     // other image types are int 0-255.
@@ -185,7 +174,7 @@ void Straight::init(std::map<std::string, std::string> &params) {
             }
         }
     };
-    subscribe<std::vector<sensor::AirSimSensorType>>("LocalNetwork", "AirSim", airsim_cb);
+    subscribe<std::vector<sensor::AirSimImageType>>("LocalNetwork", "AirSimImages", airsim_cb);
 #endif
 
 #if ENABLE_OPENCV == 1


### PR DESCRIPTION
Send AirSim data to ROS through scrimmage, Lidar and Images use separate scrimmage publishers, implemented ROS TF2 transform for Lidar.