### PR TITLE
Feature/printer

### DIFF
--- a/include/scrimmage/entity/Entity.h
+++ b/include/scrimmage/entity/Entity.h
@@ -77,6 +77,7 @@ class Entity : public std::enable_shared_from_this<Entity> {
               FileSearchPtr &file_search,
               RTreePtr &rtree,
               PubSubPtr &pubsub,
+              PrintPtr &printer,
               TimePtr &time,
               const ParameterServerPtr &param_server,
               const GlobalServicePtr &global_services,
@@ -190,12 +191,17 @@ class Entity : public std::enable_shared_from_this<Entity> {
         return pubsub_;
     }
 
+    PrintPtr & printer() {
+        return printer_;
+    }
+
     const ParameterServerPtr& param_server() {
         return param_server_;
     }
 
     double radius() { return radius_; }
     void set_time_ptr(TimePtr t);
+    void set_printer(PrintPtr printer);
 
     ///@}
 
@@ -238,6 +244,7 @@ class Entity : public std::enable_shared_from_this<Entity> {
     PluginManagerPtr plugin_manager_;
     FileSearchPtr file_search_;
     PubSubPtr pubsub_;
+    PrintPtr printer_;
     GlobalServicePtr global_services_;
     ParameterServerPtr param_server_;
     TimePtr time_;

--- a/include/scrimmage/entity/EntityPlugin.h
+++ b/include/scrimmage/entity/EntityPlugin.h
@@ -131,6 +131,7 @@ class EntityPlugin : public Plugin {
     void set_time(const std::shared_ptr<Time> &time) { time_ = time; }
     // cppcheck-suppress passedByValue
     void set_time(std::shared_ptr<const Time> time) { time_ = time; }
+    std::shared_ptr<const Time> getTime() { return time_; }
 
     void draw_shape(scrimmage_proto::ShapePtr s);
     bool print_err_on_exit = true;

--- a/include/scrimmage/entity/External.h
+++ b/include/scrimmage/entity/External.h
@@ -38,6 +38,7 @@
 #include <scrimmage/common/DelayedTask.h>
 #include <scrimmage/entity/Entity.h>
 #include <scrimmage/log/Log.h>
+#include <scrimmage/log/Print.h>
 #include <scrimmage/math/State.h>
 #include <scrimmage/motion/Controller.h>
 #include <scrimmage/proto/ProtoConversions.h>
@@ -122,6 +123,7 @@ class External {
     std::shared_ptr<Log> log_;
     double last_t_;
     PubSubPtr pubsub_;
+    PrintPtr printer_;
     TimePtr time_;
     ParameterServerPtr param_server_;
     GlobalServicePtr global_services_;

--- a/include/scrimmage/fwd_decl.h
+++ b/include/scrimmage/fwd_decl.h
@@ -79,6 +79,9 @@ using EntityPtr = std::shared_ptr<Entity>;
 class Time;
 using TimePtr = std::shared_ptr<Time>;
 
+class Print;
+using PrintPtr = std::shared_ptr<Print>;
+
 class ParameterBase;
 using ParameterBasePtr = std::shared_ptr<ParameterBase>;
 

--- a/include/scrimmage/log/Print.h
+++ b/include/scrimmage/log/Print.h
@@ -82,6 +82,7 @@ class Print {
     void init(TimePtr &time, std::string log_dir);
     void init(TimePtr &time, std::string log_dir, PrintEnums::WRITE_TO flag);
     void close();
+    void flush();
 
     void printDev(PrintData &data, std::string outmessage);
     void printInfo(PrintData &data, std::string outmessage);

--- a/include/scrimmage/log/Print.h
+++ b/include/scrimmage/log/Print.h
@@ -1,0 +1,120 @@
+/*
+ * ---------------------------------------------------------------------------
+ * @section LICENSE
+ *
+ * Copyright (c) 2020 Georgia Tech Research Institute (GTRI)
+ *               All Rights Reserved
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ * ---------------------------------------------------------------------------
+ * @file filename.ext
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @version 1.0
+ * ---------------------------------------------------------------------------
+ * @brief A brief description.
+ *
+ * @section DESCRIPTION
+ * A long description.
+ * ---------------------------------------------------------------------------
+ */
+
+#ifndef INCLUDE_SCRIMMAGE_LOG_PRINT_H_
+#define INCLUDE_SCRIMMAGE_LOG_PRINT_H_
+
+#include <scrimmage/fwd_decl.h>
+#include <scrimmage/plugin_manager/Plugin.h>
+
+#include <memory>
+#include <fstream>
+#include <ostream>
+#include <cmath>
+
+namespace scrimmage {
+
+class Time;
+using TimePtr = std::shared_ptr<Time>;
+
+
+struct PrintEnums
+{
+    enum class WARN_LEVEL : char {
+        DEV = 0,
+        INFO = 1,
+        WARNING = 2,
+        ERROR = 3
+    };
+    enum class WRITE_TO : char {
+        BOTH = 0,
+        FILE_ONLY = 1,
+        CONSOLE_ONLY = 2
+    };
+};
+
+
+
+
+
+struct PrintData {
+  PrintData() : time_(std::nan("")), name_("UnknownClass"), entity_id_(-1) {}
+  double time_;
+  std::string name_;
+  int entity_id_;
+};
+
+
+
+
+
+class Print {
+  public:
+    Print() : time_(nullptr), log_dir_(""), output_flag_(PrintEnums::WRITE_TO::BOTH) {}
+
+    void init(TimePtr &time, std::string log_dir);
+    void init(TimePtr &time, std::string log_dir, PrintEnums::WRITE_TO flag);
+    void close();
+
+    void printDev(PrintData &data, std::string outmessage);
+    void printInfo(PrintData &data, std::string outmessage);
+    void printWarning(PrintData &data, std::string outmessage);
+    void printError(PrintData &data, std::string outmessage);
+
+    void printDev(EntityPlugin &caller, std::string outmessage);
+    void printInfo(EntityPlugin &caller, std::string outmessage);
+    void printWarning(EntityPlugin &caller, std::string outmessage);
+    void printError(EntityPlugin &caller, std::string outmessage);
+
+  protected:
+    static const char* getWarningLevel(PrintEnums::WARN_LEVEL e);
+
+    static std::string formatTime(double time);
+    static std::string formatMsg(PrintEnums::WARN_LEVEL level, PrintData &data, std::string msg);
+
+    void print(std::ostream& stream, PrintEnums::WARN_LEVEL level, EntityPlugin &caller, std::string msg);
+    void print(std::ostream& stream, PrintEnums::WARN_LEVEL level, PrintData &data, std::string msg);
+
+  private:
+    TimePtr time_;
+    std::string log_dir_;
+    std::ofstream log_stream_;
+    PrintEnums::WRITE_TO output_flag_;
+  
+    bool write_file();
+    bool write_console();
+
+  };
+
+using PrintPtr = std::shared_ptr<Print>;
+
+} // namespace scrimmage
+
+#endif // INCLUDE_SCRIMMAGE_LOG_PRINT_H_

--- a/include/scrimmage/plugins/sensor/LOSSensor/LOSSensor.h
+++ b/include/scrimmage/plugins/sensor/LOSSensor/LOSSensor.h
@@ -34,7 +34,7 @@
 
 #include <scrimmage/plugins/sensor/RayTrace/RayTrace.h>
 
-#include <eigen3/Eigen/Dense>
+#include <Eigen/Dense>
 
 #include <map>
 #include <string>

--- a/include/scrimmage/simcontrol/SimControl.h
+++ b/include/scrimmage/simcontrol/SimControl.h
@@ -391,6 +391,7 @@ class SimControl {
     bool reset_autonomies();
 
     std::shared_ptr<Log> log_;
+    PrintPtr printer_;
 
     std::set<EndConditionFlags> end_conditions_ = {EndConditionFlags::NONE};
 

--- a/include/scrimmage/simcontrol/SimUtils.h
+++ b/include/scrimmage/simcontrol/SimUtils.h
@@ -56,6 +56,7 @@ struct SimUtilsInfo {
     FileSearchPtr file_search;
     RTreePtr rtree;
     PubSubPtr pubsub;
+    PrintPtr printer;
     TimePtr time;
     ParameterServerPtr param_server;
     RandomPtr random;

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -16,7 +16,7 @@ set(SRCS
     common/Shape.cpp
     entity/Contact.cpp entity/Entity.cpp entity/External.cpp
     entity/EntityPlugin.cpp
-    log/FrameUpdateClient.cpp log/Log.cpp
+    log/FrameUpdateClient.cpp log/Log.cpp log/Print.cpp
     math/Angles.cpp math/Quaternion.cpp math/State.cpp
     math/StateWithCovariance.cpp
     metrics/Metrics.cpp

--- a/src/entity/Entity.cpp
+++ b/src/entity/Entity.cpp
@@ -79,6 +79,7 @@ bool Entity::init(AttributeMap &overrides,
                   FileSearchPtr &file_search,
                   RTreePtr &rtree,
                   PubSubPtr &pubsub,
+                  PrintPtr &printer,
                   TimePtr &time,
                   const ParameterServerPtr &param_server,
                   const GlobalServicePtr &global_services,
@@ -86,6 +87,7 @@ bool Entity::init(AttributeMap &overrides,
                   std::function<void(std::map<std::string, std::string>&)> param_override_func,
                   const int& debug_level) {
     pubsub_ = pubsub;
+    printer_ = printer;
     global_services_ = global_services;
     time_ = time;
     file_search_ = file_search;
@@ -692,6 +694,7 @@ void Entity::close(double t) {
     plugin_manager_ = nullptr;
     file_search_ = nullptr;
     pubsub_ = nullptr;
+    printer_ = nullptr;
     global_services_ = nullptr;
     time_ = nullptr;
 }
@@ -701,6 +704,8 @@ std::unordered_map<std::string, MessageBasePtr> &Entity::properties() {
 }
 
 void Entity::set_time_ptr(TimePtr t) {time_ = t;}
+void Entity::set_printer(PrintPtr printer) { printer_ = printer; }
+
 
 // cppcheck-suppress passedByValue
 void Entity::set_projection(const std::shared_ptr<GeographicLib::LocalCartesian> &proj) {

--- a/src/entity/External.cpp
+++ b/src/entity/External.cpp
@@ -78,6 +78,7 @@ External::External() :
     log_(std::make_shared<Log>()),
     last_t_(NAN),
     pubsub_(std::make_shared<PubSub>()),
+    printer_(std::make_shared<Print>()),
     time_(std::make_shared<Time>()),
     param_server_(std::make_shared<ParameterServer>()),
     global_services_(std::make_shared<GlobalService>()),
@@ -165,6 +166,7 @@ bool External::create_entity(const std::string &mission_file,
     sim_info.file_search = file_search;
     sim_info.rtree = rtree;
     sim_info.pubsub = pubsub_;
+    sim_info.printer = printer_;
     sim_info.time = time_;
     sim_info.random = random;
     sim_info.id_to_team_map = id_to_team_map_;
@@ -211,7 +213,7 @@ bool External::create_entity(const std::string &mission_file,
             attr_map, info, id_to_team_map_, id_to_ent_map_, contacts, mp_,
             mp_->projection(), entity_id,
             it_name_id->second, plugin_manager_, file_search, rtree, pubsub_,
-            time_, param_server_, global_services_, plugin_tags,
+            printer_, time_, param_server_, global_services_, plugin_tags,
             param_override_func, debug_level);
     if (!ent_success) {
         std::cout << "External::create_entity() failed on entity_->init()" << std::endl;

--- a/src/log/Print.cpp
+++ b/src/log/Print.cpp
@@ -1,0 +1,232 @@
+/*
+ * ---------------------------------------------------------------------------
+ * @section LICENSE
+ *
+ * Copyright (c) 2020 Georgia Tech Research Institute (GTRI)
+ *               All Rights Reserved
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+ * FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+ * DEALINGS IN THE SOFTWARE.
+ * ---------------------------------------------------------------------------
+ * @file filename.ext
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @version 1.0
+ * ---------------------------------------------------------------------------
+ * @brief A brief description.
+ *
+ * @section DESCRIPTION
+ * Example usage
+ *
+ * // Required Includes:
+ *   #include <scrimmage/entity/Entity.h>
+ *   #include <scrimmage/log/Print.h>
+ *
+ * // In a Plugin (any type):
+ * In the _step() method, for example:
+ *   this->parent()->printer()->printInfo(*this, "Printing from my plugin!");
+ *
+ *   // or
+ *
+ *   // requires: #include <sstream>
+ *   std::ostringstream o;
+ *   o << "Testing:" << std::endl;
+ *   o << "    multiline " << std::endl;
+ *   o << "    prints " << std::endl;
+ *   this->parent()->printer()->printInfo(*this, o.str());
+ *
+ *
+ * // In a lambda:
+ *   auto mycallback = [=] (auto &somethingorother) {
+ *                      ^
+ *      // or
+ *
+ *   auto mycallback = [&,this] (auto &somethingorother) {
+ *       //               ^^^^
+ *       some_value_ = somethingorother->data;
+ *       this->parent()->printer()->printDev(*this, "Somethingorother set!");
+ *   };
+ *
+ * // In a utility class:
+ *   'this' pointer of the calling plugin must be passed into the utility
+ *   class/function/method and can be used as normal.
+ *
+ *
+ * ---------------------------------------------------------------------------
+ */
+
+#include <scrimmage/log/Print.h>
+
+#include <scrimmage/common/Time.h>
+#include <scrimmage/entity/EntityPlugin.h>
+#include <scrimmage/entity/Entity.h>
+
+#include <iostream>
+#include <iomanip>
+#include <sstream>
+#include <fstream>
+#include <ostream>
+#include <memory>
+#include <map>
+
+
+namespace scrimmage {
+
+  void Print::init(TimePtr &time, std::string log_dir) {
+      init(time, log_dir, PrintEnums::WRITE_TO::BOTH);
+  }
+  void Print::init(TimePtr &time, std::string log_dir, PrintEnums::WRITE_TO flag) {
+      time_ = time;
+      log_dir_ = log_dir;
+      output_flag_ = flag;
+
+      if ( write_file() ) {
+          std::ostringstream filename;
+          filename << log_dir_ << '/' << "console.log";
+           log_stream_.open(filename.str());
+      }
+  }
+  void Print::close() {
+      if ( log_stream_ ) {
+          log_stream_.close();
+      }
+      time_ = nullptr;
+  }
+
+
+
+
+
+  void Print::printDev(PrintData &data, std::string outmessage) {
+      print(std::cout, PrintEnums::WARN_LEVEL::DEV, data, outmessage);
+  }
+  void Print::printInfo(PrintData &data, std::string outmessage) {
+      print(std::cout, PrintEnums::WARN_LEVEL::INFO, data, outmessage);
+  }
+  void Print::printWarning(PrintData &data, std::string outmessage) {
+      print(std::cout, PrintEnums::WARN_LEVEL::WARNING, data, outmessage);
+  }
+  void Print::printError(PrintData &data, std::string outmessage) {
+      print(std::cerr, PrintEnums::WARN_LEVEL::ERROR, data, outmessage);
+  }
+
+
+  void Print::printDev(EntityPlugin &caller, std::string outmessage) {
+      print(std::cout, PrintEnums::WARN_LEVEL::DEV, caller, outmessage);
+  }
+  void Print::printInfo(EntityPlugin &caller, std::string outmessage) {
+      print(std::cout, PrintEnums::WARN_LEVEL::INFO, caller, outmessage);
+  }
+  void Print::printWarning(EntityPlugin &caller, std::string outmessage) {
+      print(std::cerr, PrintEnums::WARN_LEVEL::WARNING, caller, outmessage);
+  }
+  void Print::printError(EntityPlugin &caller, std::string outmessage) {
+      print(std::cerr, PrintEnums::WARN_LEVEL::ERROR, caller, outmessage);
+  }
+
+
+
+
+
+  const char* Print::getWarningLevel(PrintEnums::WARN_LEVEL e)
+  {
+      const std::map<PrintEnums::WARN_LEVEL, const char*> GetAsStrings {
+          { PrintEnums::WARN_LEVEL::DEV,     "DEV" },
+          { PrintEnums::WARN_LEVEL::INFO,    "INFO" },
+          { PrintEnums::WARN_LEVEL::WARNING, "WARN" },
+          { PrintEnums::WARN_LEVEL::ERROR,   "ERROR" }
+      };
+      auto   it  = GetAsStrings.find(e);
+      return it == GetAsStrings.end() ? GetAsStrings.begin()->second : it->second;
+  }
+  bool Print::write_file() {
+    return ( (output_flag_ == PrintEnums::WRITE_TO::BOTH) || (output_flag_ == PrintEnums::WRITE_TO::FILE_ONLY) );
+  }
+  bool Print::write_console() {
+    return ( (output_flag_ == PrintEnums::WRITE_TO::BOTH) || (output_flag_ == PrintEnums::WRITE_TO::CONSOLE_ONLY) );
+  }
+
+
+
+
+
+
+
+  std::string Print::formatTime(double time) {
+      if (std::isnan( time )) {
+          return "-----.---";
+      }
+      else {
+          std::ostringstream o;
+          o << std::internal << std::fixed << std::setprecision(3)
+            << std::setw(9) << std::setfill('0') << time;
+          return o.str();
+      }
+  }
+
+
+  std::string Print::formatMsg(PrintEnums::WARN_LEVEL level, PrintData &data, std::string msg) {
+      std::ostringstream pre;
+      std::ostringstream formattedmsg;
+      std::string entitySection = "";
+
+      // add entity_id if available
+      if (data.entity_id_ > 0) {
+          entitySection = "[Entity: " + std::to_string(data.entity_id_) + "]";
+      }
+
+      // create our prefix
+      pre << formatTime(data.time_) << "s [" << data.name_ << "]" << entitySection << "[" << Print::getWarningLevel(level) << "]: ";
+
+      // remove last character if it's a newline
+      if (msg.back() == '\n') {
+          msg.pop_back(); 
+      }
+
+      // iterate and place the prefix at the beginning of each newline
+      formattedmsg << pre.str();
+      for (auto i = msg.cbegin() ; i != msg.cend() ; ++i) {
+          formattedmsg << *i;
+          // add prefix after each newline
+          if (*i == '\n') {
+              formattedmsg << pre.str();
+          }
+      }
+
+      return formattedmsg.str();
+  }
+
+
+
+
+
+
+
+  void Print::print(std::ostream& stream, PrintEnums::WARN_LEVEL level, EntityPlugin &caller, std::string msg) {
+      PrintData pd;
+      pd.time_ = caller.getTime()->t();
+      pd.name_ = caller.name();
+      pd.entity_id_ = caller.parent()->id().id();
+
+      print(stream, level, pd, msg);
+  }
+  void Print::print(std::ostream& stream, PrintEnums::WARN_LEVEL level, PrintData &data, std::string msg) {
+      std::ostringstream o;
+
+      o << formatMsg(level, data, msg) << std::endl;
+
+      if ( write_file() ) { log_stream_ << o.str(); } // write to log file
+      if ( write_console() ) { stream << o.str(); } // write to console
+ }
+
+
+} // namespace scrimmage
+

--- a/src/log/Print.cpp
+++ b/src/log/Print.cpp
@@ -100,6 +100,11 @@ namespace scrimmage {
       }
       time_ = nullptr;
   }
+  void Print::flush() {
+      if (log_stream_) {
+          log_stream_.flush();
+      }
+  }
 
 
 

--- a/src/simcontrol/SimUtils.cpp
+++ b/src/simcontrol/SimUtils.cpp
@@ -90,6 +90,7 @@ bool create_ent_inters(const SimUtilsInfo &info,
             ent_inter->parent()->rtree() = info.rtree;
             ent_inter->parent()->contacts() = contacts;
             ent_inter->parent()->set_global_services(global_services);
+            ent_inter->parent()->set_printer(info.printer);
 
             // Plugin specific members
             ent_inter->set_name(name);
@@ -149,6 +150,7 @@ bool create_metrics(const SimUtilsInfo &info,
             metrics->parent()->set_projection(info.mp->projection());
             metrics->parent()->rtree() = info.rtree;
             metrics->parent()->contacts() = contacts;
+            metrics->parent()->set_printer(info.printer);
 
             // Plugin specific members
             metrics->set_name(metrics_name);
@@ -250,6 +252,7 @@ bool create_networks(const SimUtilsInfo &info, NetworkMap &networks,
             // If the name was overridden, use the override.
             std::string name =
                 get<std::string>("name", config_parse.params(), network_name);
+            network->parent()->set_printer(info.printer);
             network->set_name(name);
             network->set_mission_parse(info.mp);
             network->set_time(info.time);


### PR DESCRIPTION
Added a printer utility class for the purposes of standardizing console print formatting (prints to `stdout` and `stderr`) to make it easily parse-able, as well as sending the prints to an output file in the log directory for later perusal (no more `$ scrimmage mission.xml > foo.log`). This was developed as part of a different internal GTRI project.

The `src/log/Print.cpp` file contains usage info in a comment.
The `include/scrimmage/log/Print.h` contains the publicly accessible prototype methods.

---

Sample output (from file located in `~/.scrimmage/log/latest/console.log`):
```
00000.010s [OfficePlugin][Entity: 8][ERROR]: No coworkers in list.  The owner of this office should be in the list too.
00000.010s [GetStuffDonePlugin][Entity: 8][INFO]: Setting employee (10) of 25 employee(s) as the boss
00024.540s [WorkerBeePlugin][Entity: 9][DEV]: Received task from my boss!
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]: Received a message to start bidding war for Task 3!
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]: Task:
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]:   [task::Task] --
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]:     sender_id: 10
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]:     id: 3
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]:     status: assigned
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]:     params = 1, 2, 3, 4, 5, 6, 7, 8, 9, 10,
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]:     assignees = 13, 14, 15, 16,
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]:     task_type: my_task
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]:     last updated: 12.04
00029.060s [GetStuffDonePlugin][Entity: 10][INFO]:
00029.060s [GetStuffDonePlugin][Entity: 14][INFO]: Employee 14 publishing bid of 2.57067 for task 3.
```
---

# In a Plugin Class
All plugin classes are supported. This includes plugins that don't belong to one single entity:
* autonomy
* controller
* interaction
* metrics
* motion
* network
* sensor

Required includes for usage in a plugin class:
 *   `#include <scrimmage/entity/Entity.h>`
 *   `#include <scrimmage/log/Print.h>`

Usage, in the `step()` method of a plugin class, for example:
```
this->parent()->printer()->printInfo(*this, "Printing from my plugin!");
```
or
```
// requires: #include <sstream>
std::ostringstream o;
o << "Testing:" << std::endl;
o << "    multiline " << std::endl;
o << "    prints " << std::endl;
this->parent()->printer()->printDev(*this, o.str());
```

---
## In Lambdas

It can also be used in lambdas in plugin classes, like so:
```
   auto mycallback = [=] (auto &somethingorother) {
       //             ^
       this->parent()->printer()->printDev(*this, "Something happened!");
   };
```
or
```
   auto mycallback = [&,this] (auto &somethingorother) {
       //               ^^^^
       some_value_ = somethingorother->data;
       this->parent()->printer()->printDev(*this, "Some Value set!");
   };
```

---
## Public Methods

Methods available to plugins:
```
    void printDev(EntityPlugin &caller, std::string outmessage);
    void printInfo(EntityPlugin &caller, std::string outmessage);
    void printWarning(EntityPlugin &caller, std::string outmessage);
    void printError(EntityPlugin &caller, std::string outmessage);
```

---
# Non-Plugin Utility Classes/Methods

This isn't really well-supported. The plugin calling the utility class may pass in the printer (`this->parent()->printer()`) as an `scrimmage::PrintPtr &printer` type (or `std::shared_ptr<scrimmage::Print>` type), and may pass the `this` pointer of the calling plugin as an `EntityPlugin &` type to the utility class/method, to get this to work.

Inclusion of this header may be required in the utility's header file:
```
#include <scrimmage/fwd_decl.h>
```
Instead of the `this` pointer to the plugin, a `PrintData` struct can be filled in and sent as input instead:
```
      PrintData pd;
      pd.time_ = t;                 // double; default: nan
      pd.name_ = CLASS_NAME;        // std::string; default: "UnknownClass"
      pd.entity_id_ = entity_id;    // int; default: -1
      printer->printDev(pd, "Stepping one frame!");     // Decl: scrimmage::PrintPtr printer;
```
using the methods:
```
    void printDev(PrintData &data, std::string outmessage);
    void printInfo(PrintData &data, std::string outmessage);
    void printWarning(PrintData &data, std::string outmessage);
    void printError(PrintData &data, std::string outmessage);
```
