### PR TITLE
Build Script Updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,13 +52,9 @@ A list of the Ubuntu packages required is provided in
 installer to install the required packages:
 
     $ cd scrimmage
-    $ sudo ./setup/install-binaries.sh -e 0 -p 3
+    $ sudo ./setup/install-binaries.sh [--external] [--python <version>]
 
-The first argument `-e 0` says to install all dependencies for all features in
-SCRIMMAGE (you would use `-e 1` if you wanted to run SCRIMMAGE as part of an
-embedded system). The second argument `-p 3` says to install python3
-dependencies (use `-p a` for both python2 and 3 or `-p 2` for just python2
-dependencies).
+If the first option `--external` is passed, the script only installs what is necessary for an external build (see EXTERNAL flag to project CMakeLists.txt). The second argument `--python <version>` selects the version of python for which to install dependencies. Supported values for `<version>` are "2", "3", and "a", with "a" installing dependencies for both python 2 and 3. This option defaults to "a" if no valid version is specified.
 
 ### Install Custom Built Binary Dependencies
 

--- a/ci/dockerfiles/ubuntu-16.04
+++ b/ci/dockerfiles/ubuntu-16.04
@@ -27,6 +27,7 @@ RUN echo "deb http://packages.ros.org/ros/ubuntu xenial main" > /etc/apt/sources
     ros-kinetic-opencv3 \
     ros-kinetic-tf2 \
     ros-kinetic-mavros-msgs \
+    dc \
  && add-apt-repository ppa:kevin-demarco/scrimmage \
  && apt-get update \
  && apt-get install -y scrimmage-dependencies \

--- a/setup/install-binaries.sh
+++ b/setup/install-binaries.sh
@@ -35,7 +35,7 @@
 usage()
 {
     cat << EOF
-usage: sudo $0 -e
+usage: sudo $0
 This script installs all required dependencies.
 
 OPTIONS
@@ -53,6 +53,23 @@ OPTIONS
         The default is "a".
 EOF
 }
+
+###################################################################
+# Process input parameters to assign state of external flag and
+# Python version variables
+###################################################################
+EXTERNAL=false
+PYTHON_VERSION="a"
+
+while (( "$#" )); do
+    if [[ "$1" = "--python" ]] && ([[ "$2" = "2" ]] || [[ "$2" = "3" ]]); then
+        PYTHON_VERSION="$2"
+    elif [[ "$1" = "--external" ]]; then
+		EXTERNAL=true
+    fi
+
+    shift
+done
 
 ###################################################################
 # Dependencies array.
@@ -85,7 +102,7 @@ DEPS_DPKG=(
     unzip
 )
 
-if ( [ "$1" != "--external" ] ) && ( [ "$3" != "--external" ] ); then
+if [ "$EXTERNAL" = false ]; then
     DEPS_DPKG+=(
         ccache
         parallel
@@ -95,18 +112,11 @@ if ( [ "$1" != "--external" ] ) && ( [ "$3" != "--external" ] ); then
         libopencv-dev
         libvtk6-dev
     )
-    if [ "18.04" == ${UBUNTU_VERSION} ]; then
+    if ! echo "$UBUNTU_VERSION 18.04 -p" | dc | grep > \dev\null ^-; then
         DEPS_DPKG+=(tcl-vtk7)
     else
         DEPS_DPKG+=(tcl-vtk)
     fi
-fi
-
-PYTHON_VERSION="a"
-if [[ "$1" = "--python" ]]; then
-    PYTHON_VERSION="$2"
-elif  [[ "$3" = "--python" ]]; then
-    PYTHON_VERSION="$4"
 fi
 
 if [[ "$PYTHON_VERSION" = "2" ]] || [[ "$PYTHON_VERSION" = "a" ]]; then


### PR DESCRIPTION
Just updated the installation procedures a bit to match the current arguments to the install-binaries.sh script. Also changed the way the arguments are handled by that script to handle any ordering or weird combinations users might come up with.

Replying to comments on previous PR:

- The updated script is written such that you can pass in extra arguments like -p and -e without breaking anything. As the script currently is, I don't think those flags actually do anything. I can add a check to look for those flags as well in addition to --external or --python respectively, but that would actually be introducing a change. (I stumbled on this because I was trying to install python 3 support and -p 3 was not doing anything, it was still defaulting to installing both 2 and 3 support).

- The version checking line ( ! echo "$UBUNTU_VERSION 18.04 -p" | dc | grep > \dev\null ^-) is future compatibility. It should trigger if the Ubuntu version is greater than or equal to 18.04. It definitely could be more readable so if anyone has any other suggestions for how to do this check more cleanly just let me know and I'll make the change.
