### PR TITLE
Fix to SimControl::finalize function to correct SimpleCollisionMetrics output

### DIFF
--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -1016,6 +1016,11 @@ bool SimControl::finalize() {
         pub_ent_pres_end_->publish(msg);
     }
 
+    // Run the networks one final time to send out the messages sent above
+    // Then trigger the metric callbacks to run 
+    run_networks();
+    br::for_each(metrics_, run_callbacks);
+
     run_logging();
 
     if (display_progress_) cout << endl;


### PR DESCRIPTION
Added a final call to run_networks() and then trigger the metric callbacks after the EntityPresentAtEnd messages are published in SimControl::finalize(). This fixes the bug where these messages never arrive to the SimpleCollisionMetrics plugin, which causes all teams to always show up as not having survived. 

This fix also seems to correct the total flight time metric for the single agent during runs of the straight mission when it survives. The length of the straight mission is 100 seconds, so if the single agent team survives, the expected total flight time for that team is also 100. Prior to making this change I was getting total flight times of 53 (I guess this might vary but it seems pretty stable for me) when the single agent team survives. After the fix the total flight time shows 99.9.