### PR TITLE
Update GPS.proto

### DIFF
--- a/msgs/GPS.proto
+++ b/msgs/GPS.proto
@@ -7,9 +7,9 @@ package scrimmage_msgs;
 
 message GPSStatus {
 	int32 sender_id = 1;
-	sint64 lat = 2; 	// Possibly negative value
-	sint64 lon = 3; 	// Possibly negative value
-	sint64 alt = 4; 	// Possibly negative value
+	double lat = 2; 	// Possibly negative value
+	double lon = 3; 	// Possibly negative value
+	double alt = 4; 	// Possibly negative value
 	double time = 5;
 	bool fixed = 6;
 }


### PR DESCRIPTION
Correcting GPS message from signed int to double, as GPS coords were being truncated from GPS plugin.