### PR TITLE
added optional argument of enable_gui with ardupilot SITL

### DIFF
--- a/missions/arducopter.xml
+++ b/missions/arducopter.xml
@@ -6,7 +6,7 @@
   <!--  <run start="0.0" end="100" dt="0.00833333" -->
   <run start="0.0" end="10000000" dt="0.001"
        time_warp="1"
-       enable_gui="true"
+       enable_gui="${enable_gui=true}"
        network_gui="false"
        start_paused="false"/>
 

--- a/missions/arduplane.xml
+++ b/missions/arduplane.xml
@@ -7,7 +7,7 @@
   <run start="0.0" end="10000000" dt="0.001"
        motion_multiplier="1"
        time_warp="1"
-       enable_gui="true"
+       enable_gui="${enable_gui=true}"
        network_gui="false"
        start_paused="false"/>
 

--- a/missions/arduplane_multiple.xml
+++ b/missions/arduplane_multiple.xml
@@ -7,7 +7,7 @@
   <run start="0.0" end="10000000" dt="0.001"
        motion_multiplier="1"
        time_warp="1"
-       enable_gui="true"
+       enable_gui="${enable_gui=true}"
        network_gui="false"
        start_paused="false"/>
 


### PR DESCRIPTION
Allows ardupilot sitl to disable the gui with an additional parameter passed to sim_vehicle.py. A related merge request will be made in the Ardupilot repo to add this argument to sim_vehicle.py.
Example usage:
sim_vehicle.py -v ArduPlane -f scrimmage-plane -A"--config visual_model=cessna,motion_model=FixedWing6DOF-BlueEagle,terrain=CampAtterbury,**enable_gui=false**"