### PR TITLE
close() never called for metrics plugins in SimControl::shutdown()

### DIFF
--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -1063,6 +1063,10 @@ bool SimControl::shutdown(const bool& shutdown_python) {
         kv.second->close_plugin(t());
     }
 
+    for (MetricsPtr metric : metrics_) {
+        metric->close_plugin(t());
+    }
+
     bool status = reset_pointers();
 
 #if ENABLE_PYTHON_BINDINGS == 1


### PR DESCRIPTION
Due to an issue I was having with memory deallocation for (a custom/legacy project's) protobufs, I was looking to see if there was a method called by the simulator for a metrics plugin after all of the other metrics methods (`calc_team_scores`, `print_team_summaries`, etc) for all metrics plugins are called. It seemed like `close()` would do this, but I noticed in the simulator's `SimControl`, it was never called for metrics.

So, I added this to SimpleCollisionMetrics’s header file:
```
  void close(double /*t*/) override { std::cout << "CALLING CLOSE IN METRICS!!!" << std::endl; }
```

No printout:
```
$ scrimmage missions/straight.xml 
[===============================================================>      ] 89 %
================================================================================
SimpleCollisionMetrics
================================================================================
Team ID: 1        (Didn't survive round)
Score: 0
Entity Count: 1
Total Flight Time: 53
Total Normalized Flight Time: 1
Non-Team Collisions: 0
Team Collisions: 0
Ground Collisions: 0
----------------------------------------------------------------------
Team ID: 2        (Didn't survive round)
Score: -18
Entity Count: 30
Total Flight Time: 1570.4
Total Normalized Flight Time: 29.6302
Non-Team Collisions: 0
Team Collisions: 18
Ground Collisions: 0
----------------------------------------------------------------------
================================================================================
Overall Scores
================================================================================
Team ID: 1
Score: 0
--------------------------------------------------------------------------------
Team ID: 2
Score: -18
--------------------------------------------------------------------------------
$
```

So, I edited SimControl.cpp:
```
bool SimControl::shutdown(const bool& shutdown_python) {
    finalize();
 
    // Close all plugins
    for (EntityPtr &ent : ents_) {
        ent->close(t());
    }
 
    for (EntityInteractionPtr ent_inter : ent_inters_) {
        ent_inter->close_plugin(t());
    }
 
    for (auto &kv : *networks_) {
        kv.second->close_plugin(t());
    }
 
    for (MetricsPtr metric : metrics_) {   // <<<<<<<<<<<<<<
        metric->close_plugin(t());         // <<<<<<<<<<<<<< ADDED THESE LINES
    }                                      // <<<<<<<<<<<<<<
 
    bool status = reset_pointers();
 
/* SNIP SOME STUFF */    
 
    return status;
}
```

And I was able to see a printout at the end of the simulation:
```
$ scrimmage missions/straight.xml 
[===============================================================>      ] 89 %
================================================================================
SimpleCollisionMetrics
================================================================================
Team ID: 1        (Didn't survive round)
Score: 0
Entity Count: 1
Total Flight Time: 53
Total Normalized Flight Time: 1
Non-Team Collisions: 0
Team Collisions: 0
Ground Collisions: 0
----------------------------------------------------------------------
Team ID: 2        (Didn't survive round)
Score: -18
Entity Count: 30
Total Flight Time: 1570.4
Total Normalized Flight Time: 29.6302
Non-Team Collisions: 0
Team Collisions: 18
Ground Collisions: 0
----------------------------------------------------------------------
================================================================================
Overall Scores
================================================================================
Team ID: 1
Score: 0
--------------------------------------------------------------------------------
Team ID: 2
Score: -18
--------------------------------------------------------------------------------
CALLING CLOSE IN METRICS!!!                 <<<<<<<<<<<<<<<<<<<<<<<<<<<<< HERE
$
```

I was told by a couple of different people on the SCRIMMAGE team that this seemed like an oversight rather than intentional. So I have submitted a PR to fix this. The change is very minor.

This was tested on an Ubuntu 18.04 VirtualBox VM with a Windows 10 host. This PR is up-to-date with current master of SCRIMMAGE at the time of PR creation, namely:
```
commit 4df206756849fa3d32378410421d1170ee4a67a4 (HEAD -> master, upstream/master, origin/master, origin/HEAD)
Author: William Syre <wfsyre@gmail.com>
Date:   Tue Feb 23 12:53:00 2021 -0500

    fixed nullptr in draw_sphere (#507)
    
    Co-authored-by: William Syre <william.syre@gtri.gatech.edu>
```
