### PR TITLE
CMake updates to use environment Python by default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -93,24 +93,16 @@ GenerateSetEnv(
 option(EXTERNAL "EXTERNAL" 0)
 
 
-set(PYTHON_MIN_VERSION "" CACHE STRING "Deprecated; please use PYTHON_TARGET_VERSION instead.")
-if (PYTHON_MIN_VERSION)
-  message(DEPRECATION "!!!!!  Variable 'PYTHON_MIN_VERSION' is deprecated.\
-                       The environment default python will be used. If you\
-                       wish to specify a specific python version, please\
-                       use 'PYTHON_TARGET_VERSION' instead. !!!!!")
-endif()
-
 option(ENABLE_PYTHON_BINDINGS "ENABLE_PYTHON_BINDINGS" ON)
-set(PYTHON_TARGET_VERSION "" CACHE STRING "Target Python version for building outside of environment default Python")
+set(PYTHON_MIN_VERSION "" CACHE STRING "Minimum Python version for building, typically outside of environment default Python")
 add_library(scrimmage-python INTERFACE)
 if (ENABLE_PYTHON_BINDINGS)
 
   # Find Python
   #The order of the following find_package calls is important!
-  if (PYTHON_TARGET_VERSION)
-    find_package(PythonInterp ${PYTHON_TARGET_VERSION} REQUIRED)
-    find_package(PythonLibs ${PYTHON_TARGET_VERSION} REQUIRED)
+  if (PYTHON_MIN_VERSION)
+    find_package(PythonInterp ${PYTHON_MIN_VERSION} REQUIRED)
+    find_package(PythonLibs ${PYTHON_MIN_VERSION} REQUIRED)
   else()
     find_package(PythonInterp REQUIRED)
     find_package(PythonLibs REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,15 +92,29 @@ GenerateSetEnv(
 
 option(EXTERNAL "EXTERNAL" 0)
 
+
+set(PYTHON_MIN_VERSION "" CACHE STRING "Deprecated; please use PYTHON_TARGET_VERSION instead.")
+if (PYTHON_MIN_VERSION)
+  message(DEPRECATION "!!!!!  Variable 'PYTHON_MIN_VERSION' is deprecated.\
+                       The environment default python will be used. If you\
+                       wish to specify a specific python version, please\
+                       use 'PYTHON_TARGET_VERSION' instead. !!!!!")
+endif()
+
 option(ENABLE_PYTHON_BINDINGS "ENABLE_PYTHON_BINDINGS" ON)
-set(PYTHON_MIN_VERSION "2.7" CACHE STRING "Minimum Python version for building")
+set(PYTHON_TARGET_VERSION "" CACHE STRING "Target Python version for building outside of environment default Python")
 add_library(scrimmage-python INTERFACE)
 if (ENABLE_PYTHON_BINDINGS)
 
   # Find Python
-  #The order of the followin find_package calls is important!
-  find_package(PythonInterp ${PYTHON_MIN_VERSION} REQUIRED)
-  find_package(PythonLibs ${PYTHON_MIN_VERSION} REQUIRED)
+  #The order of the following find_package calls is important!
+  if (PYTHON_TARGET_VERSION)
+    find_package(PythonInterp ${PYTHON_TARGET_VERSION} REQUIRED)
+    find_package(PythonLibs ${PYTHON_TARGET_VERSION} REQUIRED)
+  else()
+    find_package(PythonInterp REQUIRED)
+    find_package(PythonLibs REQUIRED)
+  endif()
 
   message(STATUS "Python Versions Found: ${PYTHONLIBS_VERSION_STRING}")
   message(STATUS "PYTHON_LIBRARIES : ${PYTHON_LIBRARIES}")

--- a/README.md
+++ b/README.md
@@ -163,14 +163,14 @@ Install the python dependencies with specific version numbers:
 
 Re-build the scrimmage project within the virtual environment:
 
-    (env)$ cmake .. -DPYTHON_TARGET_VERSION=3.6
+    (env)$ cmake .. -DPYTHON_MIN_VERSION=3.6
     (env)$ make
 
-Scrimmage's cmake build procedures will by default select the
-environment default Python in its configuration process
-when running `cmake ..`. To specify a specific version of
-Python to be used, use the `cmake .. -DPYTHON_TARGET_VERSION=2.7`
-flag during the cmake process.
+Scrimmage's cmake build procedures will choose the environment
+default Python in its configuration process when running
+plain `cmake ..`. To specify a specific minimum version of Python
+to be used, use the `cmake .. -DPYTHON_MIN_VERSION=2.7` flag during
+the cmake process.
 
 ### Install SCRIMMAGE Python Bindings
 

--- a/README.md
+++ b/README.md
@@ -163,8 +163,14 @@ Install the python dependencies with specific version numbers:
 
 Re-build the scrimmage project within the virtual environment:
 
-    (env)$ cmake .. -DPYTHON_MIN_VERSION=3.6
+    (env)$ cmake .. -DPYTHON_TARGET_VERSION=3.6
     (env)$ make
+
+Scrimmage's cmake build procedures will by default select the
+environment default Python in its configuration process
+when running `cmake ..`. To specify a specific version of
+Python to be used, use the `cmake .. -DPYTHON_TARGET_VERSION=2.7`
+flag during the cmake process.
 
 ### Install SCRIMMAGE Python Bindings
 


### PR DESCRIPTION
Closes: #440 
Changes:
- Primarily, the main `CMakeLists.txt` was updated to remove the setting of `PYTHON_MIN_VERSION` to 2.7 by default.
- The `README.md` was updated to clarify what the `PYTHON_MIN_VERSION` flag is used for.

Functionality changes:
- `PYTHON_MIN_VERSION` was repurposed to not be set to anything by default, and instead allows the user to optionally specify, if they would prefer, a different python version to use than the environment default. For example, the latest anaconda (2020.11) comes with python 3.8.
- By default (no variables specified, e.g., `cmake ..`), CMake will use the environment default python version.
- Any previous scripts using this flag to automate the building of scrimmage should be backwards-compatible with these changes.

Testing:
```
$ cd build/
$ rm CMakeCache.txt
$ cmake ..                             # should use env default Python
$ rm CMakeCache.txt
$ cmake .. -DPYTHON_MIN_VERSION=2.7    # should use Python 2.7
$ rm CMakeCache.txt
$ cmake .. -DPYTHON_MIN_VERSION=3.4    # should use Python 3.7 (interpreter), 3.6 (libs) on Ubuntu 18.04 vanilla
$ rm CMakeCache.txt
$ cmake .. -DPYTHON_MIN_VERSION=3.8    # on systems with anaconda 2020.11 installed and properly configured in their path, should use Python 3.8
```

Implemented and tested on a vanilla Ubuntu 18.04 VBox VM.