### PR TITLE
Add Square Scrimmage Plugin and Initialization Maneuver for testing Visual Odometry Algorithms

### DIFF
--- a/include/scrimmage/plugins/autonomy/Square/Square.h
+++ b/include/scrimmage/plugins/autonomy/Square/Square.h
@@ -1,0 +1,105 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Natalie Rakoski <natalie.rakoski@gtri.gatech.edu>
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @date 10 April 2021
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#ifndef INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SQUARE_SQUARE_H_
+#define INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SQUARE_SQUARE_H_
+#include <scrimmage/autonomy/Autonomy.h>
+#include <scrimmage/entity/Contact.h>
+#include <scrimmage/math/Quaternion.h>
+
+#include <Eigen/Dense>
+
+#include <map>
+#include <string>
+#include <memory>
+
+namespace scrimmage {
+
+//namespace interaction {
+//class BoundaryBase;
+//}
+
+namespace autonomy {
+class Square : public scrimmage::Autonomy{
+ public:
+    void init(std::map<std::string, std::string> &params) override;
+    bool step_autonomy(double t, double dt) override;
+
+ protected:
+    double speed_;
+    Eigen::Vector3d goal_;
+    Eigen::Vector3d goal1_;
+    Eigen::Vector3d goal2_;
+    Eigen::Vector3d goal3_;
+    Eigen::Vector3d goal4_;
+
+    int frame_number_;
+    bool show_camera_images_;
+    bool save_camera_images_;
+
+//    bool enable_boundary_control_ = false;
+//    std::shared_ptr<scrimmage::interaction::BoundaryBase> boundary_;
+
+    int desired_alt_idx_ = 0;
+    int desired_speed_idx_ = 0;
+    int desired_heading_idx_ = 0;
+
+    scrimmage_proto::ShapePtr text_shape_;
+    scrimmage_proto::ShapePtr sphere_shape_;
+
+    bool noisy_state_set_ = false;
+    State noisy_state_;
+
+    ContactMap noisy_contacts_;
+
+    double desired_z_ = 0;
+
+//    PublisherPtr pub_gen_ents_;
+//    bool gen_ents_ = false;
+//    double prev_gen_time_ = -1.0;
+
+    bool use_init_maneuver_ = true;
+    bool init_maneuver_finished_ = false;
+    std::deque<State> get_init_maneuver_positions();
+    std::deque<State> man_positions_;
+    Eigen::Vector3d init_man_goal_pos_;
+    Quaternion init_man_goal_quat_;
+
+    int square_side_ = 0;
+    double sq_side_length_m_ = 100;
+    Eigen::Vector3d init_goal_;
+    // StatePtr init_state_;
+
+};
+} // namespace autonomy
+} // namespace scrimmage
+#endif // INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_SQUARE_SQUARE_H_

--- a/include/scrimmage/plugins/autonomy/Square/Square.h
+++ b/include/scrimmage/plugins/autonomy/Square/Square.h
@@ -94,10 +94,11 @@ class Square : public scrimmage::Autonomy{
     Eigen::Vector3d init_man_goal_pos_;
     Quaternion init_man_goal_quat_;
 
-    int square_side_ = 0;
+    int square_side_ = 1;
     double sq_side_length_m_ = 100;
     Eigen::Vector3d init_goal_;
     // StatePtr init_state_;
+    Eigen::Vector3d prev_diff_ = {0,0,0};
 
 };
 } // namespace autonomy

--- a/include/scrimmage/plugins/autonomy/Square/Square.h
+++ b/include/scrimmage/plugins/autonomy/Square/Square.h
@@ -49,6 +49,12 @@ namespace scrimmage {
 //}
 
 namespace autonomy {
+
+class InitManeuverType {
+ public:
+    bool active = false;
+};
+
 class Square : public scrimmage::Autonomy{
  public:
     void init(std::map<std::string, std::string> &params) override;
@@ -57,6 +63,7 @@ class Square : public scrimmage::Autonomy{
  protected:
     double speed_;
     Eigen::Vector3d goal_;
+    Eigen::Vector3d next_goal_;
     Eigen::Vector3d goal1_;
     Eigen::Vector3d goal2_;
     Eigen::Vector3d goal3_;
@@ -65,9 +72,6 @@ class Square : public scrimmage::Autonomy{
     int frame_number_;
     bool show_camera_images_;
     bool save_camera_images_;
-
-//    bool enable_boundary_control_ = false;
-//    std::shared_ptr<scrimmage::interaction::BoundaryBase> boundary_;
 
     int desired_alt_idx_ = 0;
     int desired_speed_idx_ = 0;
@@ -83,12 +87,9 @@ class Square : public scrimmage::Autonomy{
 
     double desired_z_ = 0;
 
-//    PublisherPtr pub_gen_ents_;
-//    bool gen_ents_ = false;
-//    double prev_gen_time_ = -1.0;
-
-    bool use_init_maneuver_ = true;
-    bool init_maneuver_finished_ = false;
+    PublisherPtr init_maneuver_pub_;
+    bool use_init_maneuver_ = false;
+    bool init_maneuver_finished_ = true;
     std::deque<State> get_init_maneuver_positions();
     std::deque<State> man_positions_;
     Eigen::Vector3d init_man_goal_pos_;
@@ -96,6 +97,7 @@ class Square : public scrimmage::Autonomy{
 
     int square_side_ = 1;
     double sq_side_length_m_ = 100;
+    double start_corner_turn_ = 10;
     Eigen::Vector3d init_goal_;
     // StatePtr init_state_;
     Eigen::Vector3d prev_diff_ = {0,0,0};

--- a/include/scrimmage/plugins/autonomy/Square/Square.h
+++ b/include/scrimmage/plugins/autonomy/Square/Square.h
@@ -53,6 +53,8 @@ namespace autonomy {
 class InitManeuverType {
  public:
     bool active = false;
+    Quaternion init_man_goal_quat;
+    bool stay_straight = false;
 };
 
 class Square : public scrimmage::Autonomy{

--- a/include/scrimmage/plugins/autonomy/Square/Square.xml
+++ b/include/scrimmage/plugins/autonomy/Square/Square.xml
@@ -9,4 +9,6 @@
 <!--  <generate_entities>false</generate_entities>-->
   <use_init_maneuver>false</use_init_maneuver>
   <sq_side_length_m>100</sq_side_length_m>
+  <!-- specify how many meters before the corner would you like the vehicle to start turning -->
+  <start_corner_turn>10</start_corner_turn>
 </params>

--- a/include/scrimmage/plugins/autonomy/Square/Square.xml
+++ b/include/scrimmage/plugins/autonomy/Square/Square.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
+<params>
+  <library>Square_plugin</library>
+  <speed>21</speed>
+  <show_camera_images>false</show_camera_images>
+  <save_camera_images>false</save_camera_images>
+<!--  <enable_boundary_control>false</enable_boundary_control>-->
+<!--  <generate_entities>false</generate_entities>-->
+  <use_init_maneuver>false</use_init_maneuver>
+  <sq_side_length_m>100</sq_side_length_m>
+</params>

--- a/include/scrimmage/plugins/autonomy/StraightVOInit/StraightVOInit.h
+++ b/include/scrimmage/plugins/autonomy/StraightVOInit/StraightVOInit.h
@@ -52,6 +52,8 @@ namespace autonomy {
 class InitManeuverType {
  public:
     bool active = false;
+    Quaternion init_man_goal_quat;
+    bool stay_straight = false;
 };
 
 class StraightVOInit : public scrimmage::Autonomy{

--- a/include/scrimmage/plugins/autonomy/StraightVOInit/StraightVOInit.h
+++ b/include/scrimmage/plugins/autonomy/StraightVOInit/StraightVOInit.h
@@ -1,0 +1,96 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @date 31 July 2017
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#ifndef INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_STRAIGHTVOINIT_STRAIGHTVOINIT_H_
+#define INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_STRAIGHTVOINIT_STRAIGHTVOINIT_H_
+#include <scrimmage/autonomy/Autonomy.h>
+#include <scrimmage/entity/Contact.h>
+
+#include <Eigen/Dense>
+
+#include <map>
+#include <string>
+#include <memory>
+
+namespace scrimmage {
+
+namespace interaction {
+class BoundaryBase;
+}
+
+namespace autonomy {
+
+class InitManeuverType {
+ public:
+    bool active = false;
+};
+
+class StraightVOInit : public scrimmage::Autonomy{
+ public:
+    void init(std::map<std::string, std::string> &params) override;
+    bool step_autonomy(double t, double dt) override;
+
+ protected:
+    double speed_;
+    Eigen::Vector3d goal_;
+    Eigen::Vector3d init_goal_;
+
+    int frame_number_;
+    bool show_camera_images_;
+    bool save_camera_images_;
+    bool show_text_label_;
+
+    bool enable_boundary_control_ = false;
+    std::shared_ptr<scrimmage::interaction::BoundaryBase> boundary_;
+
+    int desired_alt_idx_ = 0;
+    int desired_speed_idx_ = 0;
+    int desired_heading_idx_ = 0;
+
+    bool noisy_state_set_ = false;
+    State noisy_state_;
+    ContactMap noisy_contacts_;
+
+    double desired_z_ = 0;
+    Eigen::Vector3d prev_diff_ = {0,0,0};
+
+    PublisherPtr init_maneuver_pub_;
+    bool use_init_maneuver_ = false;
+    bool init_maneuver_finished_ = true;
+    std::deque<State> get_init_maneuver_positions();
+    std::deque<State> man_positions_;
+    Eigen::Vector3d init_man_goal_pos_;
+    Quaternion init_man_goal_quat_;
+};
+} // namespace autonomy
+} // namespace scrimmage
+#endif // INCLUDE_SCRIMMAGE_PLUGINS_AUTONOMY_STRAIGHTVOINIT_STRAIGHTVOINIT_H_

--- a/include/scrimmage/plugins/autonomy/StraightVOInit/StraightVOInit.xml
+++ b/include/scrimmage/plugins/autonomy/StraightVOInit/StraightVOInit.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
+<params>
+  <library>StraightVOInit_plugin</library>
+  <speed>21</speed>
+  <show_camera_images>false</show_camera_images>
+  <save_camera_images>false</save_camera_images>
+  <enable_boundary_control>false</enable_boundary_control>
+
+  <use_init_maneuver>false</use_init_maneuver>
+
+</params>

--- a/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h
+++ b/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h
@@ -195,6 +195,7 @@ class AirSimSensor : public scrimmage::Sensor {
     // Init Maneuver
     bool init_maneuver_active_ = false;
     Quaternion init_man_orig_quat_;
+    bool stay_straight_ = false;
 
     // period at which the data acquisition is run [seconds]
     // double data_acquisition_period_ = .1;

--- a/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h
+++ b/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h
@@ -33,7 +33,9 @@
 #define INCLUDE_SCRIMMAGE_PLUGINS_SENSOR_AIRSIMSENSOR_AIRSIMSENSOR_H_
 
 #include <scrimmage/sensor/Sensor.h>
+#include <scrimmage/math/State.h>
 #include <scrimmage/math/Angles.h>
+#include <scrimmage/math/Quaternion.h>
 #include <scrimmage/common/CSV.h>
 
 #include <random>
@@ -189,6 +191,11 @@ class AirSimSensor : public scrimmage::Sensor {
     bool get_image_data_ = true;
     bool get_lidar_data_ = true;
     bool get_imu_data_ = true;
+    bool use_init_maneuver_ = true;
+    bool init_maneuver_finished_ = false;
+    std::deque<State> get_init_maneuver_positions();
+    std::deque<State> man_positions_;
+
     // period at which the data acquisition is run [seconds]
     // double data_acquisition_period_ = .1;
     double image_acquisition_period_ = .1;

--- a/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h
+++ b/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h
@@ -134,7 +134,7 @@ class AirSimSensor : public scrimmage::Sensor {
 
  protected:
     std::string vehicle_name_ = "none";
-    bool save_data(MessagePtr<std::vector<AirSimImageType>>& im_msg, StatePtr& state, int frame_num);
+    bool save_data(MessagePtr<std::vector<AirSimImageType>>& im_msg, State state, int frame_num);
     scrimmage::CSV csv;
     int airsim_frame_num_ = 0;
 
@@ -194,7 +194,9 @@ class AirSimSensor : public scrimmage::Sensor {
     bool use_init_maneuver_ = true;
     bool init_maneuver_finished_ = false;
     std::deque<State> get_init_maneuver_positions();
+    void complete_init_maneuver();
     std::deque<State> man_positions_;
+    StatePtr init_state_;
 
     // period at which the data acquisition is run [seconds]
     // double data_acquisition_period_ = .1;

--- a/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h
+++ b/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h
@@ -191,12 +191,10 @@ class AirSimSensor : public scrimmage::Sensor {
     bool get_image_data_ = true;
     bool get_lidar_data_ = true;
     bool get_imu_data_ = true;
-    bool use_init_maneuver_ = true;
-    bool init_maneuver_finished_ = false;
-    std::deque<State> get_init_maneuver_positions();
-    void complete_init_maneuver();
-    std::deque<State> man_positions_;
-    StatePtr init_state_;
+
+    // Init Maneuver
+    bool init_maneuver_active_ = false;
+    Quaternion init_man_orig_quat_;
 
     // period at which the data acquisition is run [seconds]
     // double data_acquisition_period_ = .1;

--- a/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml
+++ b/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml
@@ -66,8 +66,6 @@
 
 
   <!-- Edit the params below in the mission file, not here -->
-  <!-- use_init_maneuver makes all aircraft perform a visual odometry initialization maneuver at the beginning of the mission -->
-  <use_init_maneuver>true</use_init_maneuver>
 
   <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs-->
   <save_airsim_data>true</save_airsim_data>

--- a/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml
+++ b/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml
@@ -66,6 +66,8 @@
 
 
   <!-- Edit the params below in the mission file, not here -->
+  <!-- use_init_maneuver makes all aircraft perform a visual odometry initialization maneuver at the beginning of the mission -->
+  <use_init_maneuver>true</use_init_maneuver>
 
   <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs-->
   <save_airsim_data>true</save_airsim_data>

--- a/missions/ALT-PNT-Chain-mission.xml
+++ b/missions/ALT-PNT-Chain-mission.xml
@@ -1,0 +1,676 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
+<runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    name="Straight flying">
+
+  <run start="0.0" end="100" dt="0.01"
+       time_warp="1"
+       enable_gui="true"
+       network_gui="false"
+       start_paused="true"/>
+
+  <display_progress>false</display_progress>
+
+  <stream_port>50051</stream_port>
+  <stream_ip>localhost</stream_ip>
+
+  <end_condition>time, all_dead</end_condition> <!-- time, one_team, none-->
+
+  <grid_spacing>10</grid_spacing>
+  <grid_size>1000</grid_size>
+
+  <terrain>mcmillan</terrain>
+  <background_color>191 191 191</background_color> <!-- Red Green Blue -->
+  <gui_update_period>10</gui_update_period> <!-- milliseconds -->
+
+  <plot_tracks>false</plot_tracks>
+  <output_type>all</output_type>
+  <show_plugins>false</show_plugins>
+
+  <metrics>SimpleCollisionMetrics</metrics>
+
+  <log_dir>~/.scrimmage/logs</log_dir>
+
+  <latitude_origin>35.721025</latitude_origin>
+  <longitude_origin>-120.767925</longitude_origin>
+  <altitude_origin>300</altitude_origin>
+  <show_origin>true</show_origin>
+  <origin_length>10</origin_length>
+
+  <entity_interaction>SimpleCollision</entity_interaction>
+  <entity_interaction>ROSClockServer</entity_interaction>
+
+  <network>GlobalNetwork</network>
+  <network>LocalNetwork</network>
+  <!-- uncomment "seed" and use integer for deterministic results -->
+  <seed>2147483648</seed>
+
+  <!-- Multiple Vehicles -->
+  <!-- User must give vehicle and lidar names specified in settings.json file on windows side for each vehicle in
+  simulation. Multiple vehicles work when multiple entities are used in a scrimmage mission where the entity count=1
+  and an AirSimSensor plugin (and if using ROS, ROSAirSim plugin) is specified in each entity. ROS topics also receive
+  sensor data under namespace from entity ID (team_id) e.g. robot1, robot2. Also images from each vehicle are saved
+  in logs under a directory related to each vehicle name. -->
+
+  <!-- ========================== Quadcopter 1 ========================= -->
+  <entity>
+    <team_id>1</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>0.0</x>
+    <y>0.0</y>
+    <z>20.0</z>
+    <heading>0</heading>
+
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- lidar_name is the name given to the lidar of the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- data_acquisition_period determines the number of times data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="10.108.21.246"
+            vehicle_name="robot1"
+            lidar_name="lidar1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            data_acquisition_period="0.01">AirSimSensor</sensor>
+
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true">Straight</autonomy>
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="1"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+    <sensor vehicle_name="robot1">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot1">ROSCompass</sensor>
+    <sensor vehicle_name="robot1">ROSIMUSensor</sensor>
+
+  </entity>
+
+  <!-- ========================== Quadcopter 2 ========================= -->
+  <entity>
+    <team_id>2</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>0.0</x>
+    <y>10.0</y>
+    <z>20.0</z>
+
+    <heading>0</heading>
+
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- lidar_name is the name given to the lidar of the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- data_acquisition_period determines the number of times data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="10.108.21.246"
+            vehicle_name="robot2"
+            lidar_name="lidar1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            data_acquisition_period="0.01">AirSimSensor</sensor>
+
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true">Straight</autonomy>
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="1"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+    <sensor vehicle_name="robot2">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot2">ROSCompass</sensor>
+    <sensor vehicle_name="robot2">ROSIMUSensor</sensor>
+
+  </entity>
+  <!-- ========================== Quadcopter 3 ========================= -->
+  <entity>
+    <team_id>3</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>-10.0</x>
+    <y>0.0</y>
+    <z>20.0</z>
+
+    <heading>0</heading>
+
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- lidar_name is the name given to the lidar of the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- data_acquisition_period determines the number of times data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="10.108.21.246"
+            vehicle_name="robot3"
+            lidar_name="lidar1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            data_acquisition_period="0.01">AirSimSensor</sensor>
+
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true">Straight</autonomy>
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="1"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+    <sensor vehicle_name="robot3">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot3">ROSCompass</sensor>
+    <sensor vehicle_name="robot3">ROSIMUSensor</sensor>
+
+  </entity>
+  <!-- ========================== Quadcopter 4 ========================= -->
+  <entity>
+    <team_id>4</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>-10.0</x>
+    <y>10.0</y>
+    <z>20.0</z>
+
+    <heading>0</heading>
+
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- lidar_name is the name given to the lidar of the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- data_acquisition_period determines the number of times data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="10.108.21.246"
+            vehicle_name="robot4"
+            lidar_name="lidar1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            data_acquisition_period="0.01">AirSimSensor</sensor>
+
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true">Straight</autonomy>
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="1"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+    <sensor vehicle_name="robot4">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot4">ROSCompass</sensor>
+    <sensor vehicle_name="robot4">ROSIMUSensor</sensor>
+
+  </entity>
+  <!-- ========================== Quadcopter 5 ========================= -->
+  <entity>
+    <team_id>5</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>-20.0</x>
+    <y>0.0</y>
+    <z>20.0</z>
+
+    <heading>0</heading>
+
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- lidar_name is the name given to the lidar of the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- data_acquisition_period determines the number of times data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="10.108.21.246"
+            vehicle_name="robot5"
+            lidar_name="lidar1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            data_acquisition_period="0.01">AirSimSensor</sensor>
+
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true">Straight</autonomy>
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="1"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+    <sensor vehicle_name="robot5">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot5">ROSCompass</sensor>
+    <sensor vehicle_name="robot5">ROSIMUSensor</sensor>
+
+  </entity>
+  <!-- ========================== Quadcopter 6 ========================= -->
+  <entity>
+    <team_id>6</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>-20.0</x>
+    <y>10.0</y>
+    <z>20.0</z>
+
+    <heading>0</heading>
+
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- lidar_name is the name given to the lidar of the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- data_acquisition_period determines the number of times data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="10.108.21.246"
+            vehicle_name="robot6"
+            lidar_name="lidar1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            data_acquisition_period="0.01">AirSimSensor</sensor>
+
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true">Straight</autonomy>
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="1"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+    <sensor vehicle_name="robot6">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot6">ROSCompass</sensor>
+    <sensor vehicle_name="robot6">ROSIMUSensor</sensor>
+
+  </entity>
+  <!-- ========================== Quadcopter 7 ========================= -->
+  <entity>
+    <team_id>7</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>-30.0</x>
+    <y>0.0</y>
+    <z>20.0</z>
+
+    <heading>0</heading>
+
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- lidar_name is the name given to the lidar of the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- data_acquisition_period determines the number of times data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="10.108.21.246"
+            vehicle_name="robot7"
+            lidar_name="lidar1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            data_acquisition_period="0.01">AirSimSensor</sensor>
+
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true">Straight</autonomy>
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="1"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+    <sensor vehicle_name="robot7">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot7">ROSCompass</sensor>
+    <sensor vehicle_name="robot7">ROSIMUSensor</sensor>
+
+  </entity>
+  <!-- ========================== Quadcopter 8 ========================= -->
+  <entity>
+    <team_id>8</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>-30.0</x>
+    <y>10.0</y>
+    <z>20.0</z>
+
+    <heading>0</heading>
+
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- lidar_name is the name given to the lidar of the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- data_acquisition_period determines the number of times data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="10.108.21.246"
+            vehicle_name="robot8"
+            lidar_name="lidar1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            data_acquisition_period="0.01">AirSimSensor</sensor>
+
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true">Straight</autonomy>
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="1"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+    <sensor vehicle_name="robot8">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot8">ROSCompass</sensor>
+    <sensor vehicle_name="robot8">ROSIMUSensor</sensor>
+
+  </entity>
+  <!-- ========================== Quadcopter 9 ========================= -->
+  <entity>
+    <team_id>9</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>-40.0</x>
+    <y>0.0</y>
+    <z>20.0</z>
+
+    <heading>0</heading>
+
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- lidar_name is the name given to the lidar of the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- data_acquisition_period determines the number of times data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="10.108.21.246"
+            vehicle_name="robot9"
+            lidar_name="lidar1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            data_acquisition_period="0.01">AirSimSensor</sensor>
+
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true">Straight</autonomy>
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="1"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+    <sensor vehicle_name="robot9">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot9">ROSCompass</sensor>
+    <sensor vehicle_name="robot9">ROSIMUSensor</sensor>
+
+  </entity>
+  <!-- ========================== Quadcopter 10 ========================= -->
+  <entity>
+    <team_id>10</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>-40.0</x>
+    <y>10.0</y>
+    <z>20.0</z>
+
+    <heading>0</heading>
+
+    <!-- airsim_ip is IP of the Windows machine running AirSim/ Unreal Engine or Localhost if Unreal Engine running on Windows-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- lidar_name is the name given to the lidar of the corresponding vehicle in the AirSim settings.json file on the Windows side -->
+    <!-- save_airsim_data saves all images and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- data_acquisition_period determines the number of times data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="10.108.21.246"
+            vehicle_name="robot10"
+            lidar_name="lidar1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            data_acquisition_period="0.01">AirSimSensor</sensor>
+
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- Make sure "get_image/lidar_data" is specified in AirSimSensor above before use. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation. -->
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <autonomy show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true">ROSAirSim</autonomy>
+
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true">Straight</autonomy>
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="1"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+    <sensor vehicle_name="robot10">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot10">ROSCompass</sensor>
+    <sensor vehicle_name="robot10">ROSIMUSensor</sensor>
+
+  </entity>
+
+</runscript>

--- a/missions/quad-airsim-ex-square.xml
+++ b/missions/quad-airsim-ex-square.xml
@@ -3,7 +3,7 @@
 <runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     name="Straight flying">
 
-  <run start="0.0" end="1500" dt="0.01"
+  <run start="0.0" end="600" dt="0.01"
        time_warp="1"
        enable_gui="true"
        network_gui="false"
@@ -39,8 +39,8 @@
 
   <entity_interaction name="blue_boundary"
                       type="cuboid"
-                      lengths="126, 126, 126"
-                      center="63, 63, 0"
+                      lengths="130, 130, 130"
+                      center="65, 65, 0"
                       color="0 0 255"
                       id="1"
                       team_id="1">Boundary</entity_interaction>
@@ -152,8 +152,8 @@
     <!-- start_corner_turn specifies how many meters before the corner you would like the vehicle to start turning -->
     <autonomy show_camera_images="true"
               use_init_maneuver="false"
-              sq_side_length_m="126"
-              start_corner_turn="20"
+              sq_side_length_m="130"
+              start_corner_turn="15"
               speed="21">Square</autonomy>
 
     <motion_model motion_model_sets_yaw="false"
@@ -262,8 +262,8 @@
     <!-- start_corner_turn specifies how many meters before the corner you would like the vehicle to start turning -->
     <autonomy show_camera_images="true"
               use_init_maneuver="false"
-              sq_side_length_m="126"
-              start_corner_turn="20"
+              sq_side_length_m="130"
+              start_corner_turn="15"
               speed="21">Square</autonomy>
 
     <motion_model motion_model_sets_yaw="false"

--- a/missions/quad-airsim-ex-square.xml
+++ b/missions/quad-airsim-ex-square.xml
@@ -3,7 +3,7 @@
 <runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     name="Straight flying">
 
-  <run start="0.0" end="100" dt="0.01"
+  <run start="0.0" end="1500" dt="0.01"
        time_warp="1"
        enable_gui="true"
        network_gui="false"
@@ -36,6 +36,14 @@
   <altitude_origin>300</altitude_origin>
   <show_origin>true</show_origin>
   <origin_length>10</origin_length>
+
+  <entity_interaction name="blue_boundary"
+                      type="cuboid"
+                      lengths="126, 126, 126"
+                      center="63, 63, 0"
+                      color="0 0 255"
+                      id="1"
+                      team_id="1">Boundary</entity_interaction>
 
   <entity_interaction>SimpleCollision</entity_interaction>
   <entity_interaction>ROSClockServer</entity_interaction>
@@ -83,15 +91,18 @@
     <!-- lidar_acquisition_period determines the number of times LIDAR data is requested from AirSim per second -->
     <!-- imu_acquisition_period determines the number of times IMU data is requested from AirSim per second -->
     <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+
+    <!-- use_init_maneuver makes all aircraft perform a visual odometry initialization maneuver at the beginning of the mission -->
     <sensor airsim_ip="127.0.0.1"
             vehicle_name="robot1"
             save_airsim_data="true"
             get_image_data="true"
             get_lidar_data="true"
-            get_imu_data="true"
+            get_imu_data="false"
             image_acquisition_period="0.33"
             lidar_acquisition_period="0.1"
-            imu_acquisition_period="0.1">AirSimSensor</sensor>
+            imu_acquisition_period="0.1"
+            use_init_maneuver="false">AirSimSensor</sensor>
 
 
     <!-- SCRIMMAGE ROS Data Plugins-->
@@ -100,9 +111,9 @@
     <!-- These SCRIMMAGE simulated sensors can not support custom location settings on the vehicle body or using multiple of each per vehicle unlike AirSim sensors.-->
     <!-- CAUTION: You can not use get_imu_data="true" in the AirSim plugin above and the ROSIMUSensor plugin below at the same time.-->
     <!-- CAUTION: To use the ROSIMUSensor plugin below, get_imu_data="false" must be set in the AirSim plugin above, else you will receive an error.-->
-<!--    <sensor vehicle_name="robot1">ROSAltimeter</sensor>-->
-<!--    <sensor vehicle_name="robot1">ROSCompass</sensor>-->
-<!--    <sensor vehicle_name="robot1">ROSIMUSensor</sensor>-->
+    <sensor vehicle_name="robot1">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot1">ROSCompass</sensor>
+    <sensor vehicle_name="robot1">ROSIMUSensor</sensor>
 
 
     <!-- ROSAirSim Plugin -->
@@ -117,19 +128,33 @@
 
     <!-- Set ros_python to "true" if using ROS's python interface, "false" uses Image Transports ROS msg for images.-->
     <!-- Set ros_cartographer to "true" if using ROS Cartographer with Scrimmage/AirSim-->
-<!--    <autonomy vehicle_name="robot1"-->
-<!--              show_camera_images="false"-->
-<!--              pub_image_data="true"-->
-<!--              pub_lidar_data="true"-->
-<!--              pub_imu_data="true"-->
-<!--              ros_python="false"-->
-<!--              ros_cartographer="false">ROSAirSim</autonomy>-->
-
+    <autonomy vehicle_name="robot1"
+              show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true"
+              pub_imu_data="true"
+              ros_python="false"
+              ros_cartographer="false">ROSAirSim</autonomy>
 
     <!-- Straight Plugin -->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
     <!-- show_camera_images shows AirSim images in windows during simulation. -->
     <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
-    <autonomy show_camera_images="true">Straight</autonomy>
+<!--    <autonomy show_camera_images="true">Straight</autonomy>-->
+
+    <!-- Square Plugin -->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
+    <!-- Default settings work well with the AirSim neighborhood environment. -->
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <!-- sq_side_length_m is the square side length in meters -->
+    <!-- Cuboid Boundary is set at top of file to visualize square-->
+    <!-- start_corner_turn specifies how many meters before the corner you would like the vehicle to start turning -->
+    <autonomy show_camera_images="true"
+              use_init_maneuver="false"
+              sq_side_length_m="126"
+              start_corner_turn="20"
+              speed="21">Square</autonomy>
 
     <motion_model motion_model_sets_yaw="false"
                   sim_copter_orientation="true"
@@ -174,15 +199,18 @@
     <!-- lidar_acquisition_period determines the number of times LIDAR data is requested from AirSim per second -->
     <!-- imu_acquisition_period determines the number of times IMU data is requested from AirSim per second -->
     <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+
+    <!-- use_init_maneuver makes all aircraft perform a visual odometry initialization maneuver at the beginning of the mission -->
     <sensor airsim_ip="127.0.0.1"
             vehicle_name="robot2"
             save_airsim_data="true"
             get_image_data="true"
             get_lidar_data="true"
-            get_imu_data="true"
+            get_imu_data="false"
             image_acquisition_period="0.33"
             lidar_acquisition_period="0.1"
-            imu_acquisition_period="0.1">AirSimSensor</sensor>
+            imu_acquisition_period="0.1"
+            use_init_maneuver="false">AirSimSensor</sensor>
 
 
     <!-- SCRIMMAGE ROS Data Plugins -->
@@ -191,9 +219,9 @@
     <!-- These SCRIMMAGE simulated sensors can not support custom location settings on the vehicle body or using multiple of each per vehicle unlike AirSim sensors.-->
     <!-- CAUTION: You can not use get_imu_data="true" in the AirSim plugin above and the ROSIMUSensor plugin below at the same time.-->
     <!-- CAUTION: To use the ROSIMUSensor plugin below, get_imu_data="false" must be set in the AirSim plugin above, else you will receive an error.-->
-<!--    <sensor vehicle_name="robot2">ROSAltimeter</sensor>-->
-<!--    <sensor vehicle_name="robot2">ROSCompass</sensor>-->
-<!--    <sensor vehicle_name="robot2">ROSIMUSensor</sensor>-->
+    <sensor vehicle_name="robot2">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot2">ROSCompass</sensor>
+    <sensor vehicle_name="robot2">ROSIMUSensor</sensor>
 
 
     <!-- ROSAirSim Plugin -->
@@ -208,19 +236,35 @@
 
     <!-- Set ros_python to "true" if using ROS's python interface, "false" uses Image Transports ROS msg for images.-->
     <!-- Set ros_cartographer to "true" if using ROS Cartographer with Scrimmage/AirSim-->
-<!--    <autonomy vehicle_name="robot2"-->
-<!--              show_camera_images="false"-->
-<!--              pub_image_data="true"-->
-<!--              pub_lidar_data="true"-->
-<!--              pub_imu_data="true"-->
-<!--              ros_python="false"-->
-<!--              ros_cartographer="false">ROSAirSim</autonomy>-->
+    <autonomy vehicle_name="robot2"
+              show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true"
+              pub_imu_data="true"
+              ros_python="false"
+              ros_cartographer="false">ROSAirSim</autonomy>
 
 
     <!-- Straight Plugin -->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
     <!-- show_camera_images shows AirSim images in windows during simulation. -->
     <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
-    <autonomy show_camera_images="true">Straight</autonomy>
+<!--    <autonomy show_camera_images="true">Straight</autonomy>-->
+
+    <!-- Square Plugin -->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
+    <!-- Default settings work well with the AirSim neighborhood environment. -->
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <!-- use_init_maneuver performs an initialization maneuver for visual odometry SLAM algorithms. -->
+    <!-- sq_side_length_m is the square side length in meters -->
+    <!-- Cuboid Boundary is set at top of file to visualize square-->
+    <!-- start_corner_turn specifies how many meters before the corner you would like the vehicle to start turning -->
+    <autonomy show_camera_images="true"
+              use_init_maneuver="false"
+              sq_side_length_m="126"
+              start_corner_turn="20"
+              speed="21">Square</autonomy>
 
     <motion_model motion_model_sets_yaw="false"
                   sim_copter_orientation="true"

--- a/missions/quad-airsim-ex-square.xml
+++ b/missions/quad-airsim-ex-square.xml
@@ -91,8 +91,6 @@
     <!-- lidar_acquisition_period determines the number of times LIDAR data is requested from AirSim per second -->
     <!-- imu_acquisition_period determines the number of times IMU data is requested from AirSim per second -->
     <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
-
-    <!-- use_init_maneuver makes all aircraft perform a visual odometry initialization maneuver at the beginning of the mission -->
     <sensor airsim_ip="127.0.0.1"
             vehicle_name="robot1"
             save_airsim_data="true"
@@ -101,8 +99,7 @@
             get_imu_data="false"
             image_acquisition_period="0.33"
             lidar_acquisition_period="0.1"
-            imu_acquisition_period="0.1"
-            use_init_maneuver="false">AirSimSensor</sensor>
+            imu_acquisition_period="0.1">AirSimSensor</sensor>
 
 
     <!-- SCRIMMAGE ROS Data Plugins-->
@@ -199,8 +196,6 @@
     <!-- lidar_acquisition_period determines the number of times LIDAR data is requested from AirSim per second -->
     <!-- imu_acquisition_period determines the number of times IMU data is requested from AirSim per second -->
     <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
-
-    <!-- use_init_maneuver makes all aircraft perform a visual odometry initialization maneuver at the beginning of the mission -->
     <sensor airsim_ip="127.0.0.1"
             vehicle_name="robot2"
             save_airsim_data="true"
@@ -209,8 +204,7 @@
             get_imu_data="false"
             image_acquisition_period="0.33"
             lidar_acquisition_period="0.1"
-            imu_acquisition_period="0.1"
-            use_init_maneuver="false">AirSimSensor</sensor>
+            imu_acquisition_period="0.1">AirSimSensor</sensor>
 
 
     <!-- SCRIMMAGE ROS Data Plugins -->

--- a/missions/quad-airsim-ex-straight_VOinit.xml
+++ b/missions/quad-airsim-ex-straight_VOinit.xml
@@ -5,7 +5,7 @@
 
   <run start="0.0" end="200" dt="0.01"
        time_warp="1"
-       enable_gui="false"
+       enable_gui="true"
        network_gui="false"
        start_paused="false"/>
 
@@ -139,7 +139,7 @@
     <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
     <!-- use_init_maneuver performs an initialization maneuver for visual odometry SLAM algorithms. -->
     <autonomy show_camera_images="false"
-              use_init_maneuver="false">StraightVOInit</autonomy>
+              use_init_maneuver="true">StraightVOInit</autonomy>
 
     <!-- Square Plugin -->
     <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
@@ -247,7 +247,7 @@
     <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
     <!-- use_init_maneuver performs an initialization maneuver for visual odometry SLAM algorithms. -->
     <autonomy show_camera_images="false"
-              use_init_maneuver="false">StraightVOInit</autonomy>
+              use_init_maneuver="true">StraightVOInit</autonomy>
 
     <!-- Square Plugin -->
     <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->

--- a/missions/quad-airsim-ex-straight_VOinit.xml
+++ b/missions/quad-airsim-ex-straight_VOinit.xml
@@ -3,7 +3,7 @@
 <runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     name="Straight flying">
 
-  <run start="0.0" end="200" dt="0.01"
+  <run start="0.0" end="400" dt="0.01"
        time_warp="1"
        enable_gui="true"
        network_gui="false"
@@ -39,8 +39,8 @@
 
   <entity_interaction name="blue_boundary"
                       type="cuboid"
-                      lengths="130, 130, 130"
-                      center="65, 65, 0"
+                      lengths="300, 300, 50"
+                      center="0, 0, 0"
                       color="0 0 255"
                       id="1"
                       team_id="1">Boundary</entity_interaction>
@@ -138,8 +138,10 @@
     <!-- show_camera_images shows AirSim images in windows during simulation. -->
     <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
     <!-- use_init_maneuver performs an initialization maneuver for visual odometry SLAM algorithms. -->
+    <!-- enable_boundary_control="true" will keep the quadcopters inside the blue boundary box. -->
     <autonomy show_camera_images="false"
-              use_init_maneuver="true">StraightVOInit</autonomy>
+              use_init_maneuver="true"
+              enable_boundary_control="false">StraightVOInit</autonomy>
 
     <!-- Square Plugin -->
     <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
@@ -246,8 +248,10 @@
     <!-- show_camera_images shows AirSim images in windows during simulation. -->
     <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
     <!-- use_init_maneuver performs an initialization maneuver for visual odometry SLAM algorithms. -->
+    <!-- enable_boundary_control="true" will keep the quadcopters inside the blue boundary box. -->
     <autonomy show_camera_images="false"
-              use_init_maneuver="true">StraightVOInit</autonomy>
+              use_init_maneuver="true"
+              enable_boundary_control="false">StraightVOInit</autonomy>
 
     <!-- Square Plugin -->
     <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->

--- a/missions/quad-airsim-ex-straight_VOinit.xml
+++ b/missions/quad-airsim-ex-straight_VOinit.xml
@@ -1,0 +1,278 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="http://gtri.gatech.edu"?>
+<runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    name="Straight flying">
+
+  <run start="0.0" end="200" dt="0.01"
+       time_warp="1"
+       enable_gui="false"
+       network_gui="false"
+       start_paused="false"/>
+
+  <display_progress>false</display_progress>
+
+  <stream_port>50051</stream_port>
+  <stream_ip>localhost</stream_ip>
+
+  <end_condition>time, all_dead</end_condition> <!-- time, one_team, none-->
+
+  <grid_spacing>10</grid_spacing>
+  <grid_size>1000</grid_size>
+
+  <terrain>mcmillan</terrain>
+  <background_color>191 191 191</background_color> <!-- Red Green Blue -->
+  <gui_update_period>10</gui_update_period> <!-- milliseconds -->
+
+  <plot_tracks>false</plot_tracks>
+  <output_type>all</output_type>
+  <show_plugins>false</show_plugins>
+
+  <metrics>SimpleCollisionMetrics</metrics>
+
+  <log_dir>~/.scrimmage/logs</log_dir>
+
+  <latitude_origin>35.721025</latitude_origin>
+  <longitude_origin>-120.767925</longitude_origin>
+  <altitude_origin>300</altitude_origin>
+  <show_origin>true</show_origin>
+  <origin_length>10</origin_length>
+
+  <entity_interaction name="blue_boundary"
+                      type="cuboid"
+                      lengths="130, 130, 130"
+                      center="65, 65, 0"
+                      color="0 0 255"
+                      id="1"
+                      team_id="1">Boundary</entity_interaction>
+
+  <entity_interaction>SimpleCollision</entity_interaction>
+  <entity_interaction>ROSClockServer</entity_interaction>
+
+  <network>GlobalNetwork</network>
+  <network>LocalNetwork</network>
+  <!-- uncomment "seed" and use integer for deterministic results -->
+  <seed>2147483648</seed>
+
+  <!-- Multiple Vehicles -->
+  <!-- User must give vehicle and lidar names specified in settings.json file on windows side for each vehicle in
+  simulation. Multiple vehicles work when multiple entities are used in a scrimmage mission where the entity count=1
+  and an AirSimSensor plugin (and if using ROS, ROSAirSim plugin) is specified in each entity. ROS topics also receive
+  sensor data under namespace from entity ID (team_id) e.g. robot1, robot2. Also images from each vehicle are saved
+  in logs under a directory related to each vehicle name. -->
+
+  <!-- ========================== Quadcopter 1 ========================= -->
+  <entity>
+    <team_id>1</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>0.0</x>
+    <y>0.0</y>
+    <z>14.0</z>
+    <heading>0</heading>
+
+
+    <!-- AirSimSensor Plugin -->
+    <!-- airsim_ip is IP of the machine running AirSim/ Unreal Engine or Localhost(127.0.0.1) if running on the same machine as Scrimmage/AirSim. -->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file. -->
+
+    <!-- save_airsim_data saves all images requested and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- get_imu_data requests imu data from AirSim -->
+
+    <!-- image_acquisition_period determines the number of times image data is requested from AirSim per second -->
+    <!-- lidar_acquisition_period determines the number of times LIDAR data is requested from AirSim per second -->
+    <!-- imu_acquisition_period determines the number of times IMU data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="127.0.0.1"
+            vehicle_name="robot1"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            image_acquisition_period="0.33"
+            lidar_acquisition_period="0.1"
+            imu_acquisition_period="0.1">AirSimSensor</sensor>
+
+
+    <!-- SCRIMMAGE ROS Data Plugins-->
+    <!-- These plugins publish useful SCRIMMAGE data to ROS -->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file. -->
+    <!-- These SCRIMMAGE simulated sensors can not support custom location settings on the vehicle body or using multiple of each per vehicle unlike AirSim sensors.-->
+    <!-- CAUTION: You can not use get_imu_data="true" in the AirSim plugin above and the ROSIMUSensor plugin below at the same time.-->
+    <!-- CAUTION: To use the ROSIMUSensor plugin below, get_imu_data="false" must be set in the AirSim plugin above, else you will receive an error.-->
+    <sensor vehicle_name="robot1">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot1">ROSCompass</sensor>
+    <sensor vehicle_name="robot1">ROSIMUSensor</sensor>
+
+
+    <!-- ROSAirSim Plugin -->
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation, use show_camera_images in Straight Plugin below when possible. -->
+
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <!-- pub_imu_data publishes IMU data to ROS when set to "true". -->
+    <!-- Make sure "get_image_data/get_lidar_data/get_imu_data" is specified in AirSimSensor above before use. -->
+
+    <!-- Set ros_python to "true" if using ROS's python interface, "false" uses Image Transports ROS msg for images.-->
+    <!-- Set ros_cartographer to "true" if using ROS Cartographer with Scrimmage/AirSim-->
+    <autonomy vehicle_name="robot1"
+              show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true"
+              pub_imu_data="true"
+              ros_python="false"
+              ros_cartographer="false">ROSAirSim</autonomy>
+
+    <!-- Straight Plugin With Visual Odometry Initialization Maneuver-->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <!-- use_init_maneuver performs an initialization maneuver for visual odometry SLAM algorithms. -->
+    <autonomy show_camera_images="false"
+              use_init_maneuver="false">StraightVOInit</autonomy>
+
+    <!-- Square Plugin -->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
+    <!-- Default settings work well with the AirSim neighborhood environment. -->
+    <!-- Cuboid Boundary is set at top of file to visualize square-->
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <!-- use_init_maneuver performs an initialization maneuver for visual odometry SLAM algorithms. -->
+    <!-- sq_side_length_m is the square side length in meters -->
+    <!-- start_corner_turn specifies how many meters before the corner you would like the vehicle to start turning -->
+    <!-- <autonomy show_camera_images="true"-->
+    <!--          use_init_maneuver="false" -->
+    <!--          sq_side_length_m="130"    -->
+    <!--          start_corner_turn="15"    -->
+    <!--          speed="21">Square</autonomy> -->
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="4"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+  </entity>
+
+  <!-- ========================== Quadcopter 2 ========================= -->
+  <entity>
+    <team_id>2</team_id>
+    <color>77 77 255</color>
+    <count>1</count>
+    <health>1</health>
+    <radius>1</radius>
+
+    <!-- Start Position in relation to Lat/ Long. If you wish to change, you will also need to change in the AirSim settings.json -->
+    <!-- Here these are in ENU, but in the settings.json you must state them in NED (ENU -> Ned = switch x & y, negate z) -->
+    <!-- Leave Z = 0.0 in the settings.json, only change Z here.-->
+    <!-- Recommended Z (below) for Assets: LandscapeMountains=100, Neighborhood=10, Africa=30, City=30, ZhangJiaJie=10 -->
+    <x>4.0</x>
+    <y>0.0</y>
+    <z>10.0</z>
+
+    <heading>0</heading>
+
+    <!-- AirSimSensor Plugin -->
+    <!-- airsim_ip is IP of the machine running AirSim/ Unreal Engine or Localhost(127.0.0.1) if running on the same machine as Scrimmage/AirSim. -->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file. -->
+
+    <!-- save_airsim_data saves all images requested and a CSV of quaternion pose values to scrimmage logs -->
+    <!-- get_image_data requests images from AirSim,see scrimmage/include/scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.xml for specifying image types -->
+    <!-- get_lidar_data requests lidar data from AirSim -->
+    <!-- get_imu_data requests imu data from AirSim -->
+
+    <!-- image_acquisition_period determines the number of times image data is requested from AirSim per second -->
+    <!-- lidar_acquisition_period determines the number of times LIDAR data is requested from AirSim per second -->
+    <!-- imu_acquisition_period determines the number of times IMU data is requested from AirSim per second -->
+    <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+    <sensor airsim_ip="127.0.0.1"
+            vehicle_name="robot2"
+            save_airsim_data="true"
+            get_image_data="true"
+            get_lidar_data="true"
+            get_imu_data="false"
+            image_acquisition_period="0.33"
+            lidar_acquisition_period="0.1"
+            imu_acquisition_period="0.1">AirSimSensor</sensor>
+
+
+    <!-- SCRIMMAGE ROS Data Plugins -->
+    <!-- These plugins publish useful SCRIMMAGE data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file. -->
+    <!-- These SCRIMMAGE simulated sensors can not support custom location settings on the vehicle body or using multiple of each per vehicle unlike AirSim sensors.-->
+    <!-- CAUTION: You can not use get_imu_data="true" in the AirSim plugin above and the ROSIMUSensor plugin below at the same time.-->
+    <!-- CAUTION: To use the ROSIMUSensor plugin below, get_imu_data="false" must be set in the AirSim plugin above, else you will receive an error.-->
+    <sensor vehicle_name="robot2">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot2">ROSCompass</sensor>
+    <sensor vehicle_name="robot2">ROSIMUSensor</sensor>
+
+
+    <!-- ROSAirSim Plugin -->
+    <!-- Publishes AirSim data to ROS, to use you must build scrimmage with -DBUILD_ROS_PLUGINS=ON-->
+    <!-- vehicle_name is the name given to the corresponding vehicle in the AirSim settings.json file. -->
+    <!-- show_camera_images shows AirSim images in OpenCV windows during simulation, use show_camera_images in Straight Plugin below when possible. -->
+
+    <!-- pub_image_data publishes image data to ROS when set to "true". -->
+    <!-- pub_lidar_data publishes LIDAR data to ROS when set to "true". -->
+    <!-- pub_imu_data publishes IMU data to ROS when set to "true". -->
+    <!-- Make sure "get_image_data/get_lidar_data/get_imu_data" is set correctly in AirSimSensor above before use. -->
+
+    <!-- Set ros_python to "true" if using ROS's python interface, "false" uses Image Transports ROS msg for images.-->
+    <!-- Set ros_cartographer to "true" if using ROS Cartographer with Scrimmage/AirSim-->
+    <autonomy vehicle_name="robot2"
+              show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true"
+              pub_imu_data="true"
+              ros_python="false"
+              ros_cartographer="false">ROSAirSim</autonomy>
+
+
+    <!-- Straight Plugin With Visual Odometry Initialization Maneuver-->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <!-- use_init_maneuver performs an initialization maneuver for visual odometry SLAM algorithms. -->
+    <autonomy show_camera_images="false"
+              use_init_maneuver="false">StraightVOInit</autonomy>
+
+    <!-- Square Plugin -->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
+    <!-- Default settings work well with the AirSim neighborhood environment. -->
+    <!-- Cuboid Boundary is set at top of file to visualize square-->
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <!-- use_init_maneuver performs an initialization maneuver for visual odometry SLAM algorithms. -->
+    <!-- sq_side_length_m is the square side length in meters -->
+    <!-- start_corner_turn specifies how many meters before the corner you would like the vehicle to start turning -->
+    <!-- <autonomy show_camera_images="true"-->
+    <!--          use_init_maneuver="false" -->
+    <!--          sq_side_length_m="130"    -->
+    <!--          start_corner_turn="15"    -->
+    <!--          speed="21">Square</autonomy> -->
+
+    <motion_model motion_model_sets_yaw="false"
+                  sim_copter_orientation="true"
+                  max_vel="4"
+                  max_acc="2"
+                  max_yaw_vel="12"
+                  max_yaw_acc="2">DoubleIntegrator</motion_model>
+    <controller>DoubleIntegratorControllerVelYaw</controller>
+    <visual_model>iris</visual_model>
+
+  </entity>
+
+</runscript>

--- a/missions/quad-airsim-ex1.xml
+++ b/missions/quad-airsim-ex1.xml
@@ -83,15 +83,18 @@
     <!-- lidar_acquisition_period determines the number of times LIDAR data is requested from AirSim per second -->
     <!-- imu_acquisition_period determines the number of times IMU data is requested from AirSim per second -->
     <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+
+    <!-- use_init_maneuver makes all aircraft perform a visual odometry initialization maneuver at the beginning of the mission -->
     <sensor airsim_ip="127.0.0.1"
             vehicle_name="robot1"
             save_airsim_data="true"
             get_image_data="true"
             get_lidar_data="true"
-            get_imu_data="true"
+            get_imu_data="false"
             image_acquisition_period="0.33"
             lidar_acquisition_period="0.1"
-            imu_acquisition_period="0.1">AirSimSensor</sensor>
+            imu_acquisition_period="0.1"
+            use_init_maneuver="true">AirSimSensor</sensor>
 
 
     <!-- SCRIMMAGE ROS Data Plugins-->
@@ -100,9 +103,9 @@
     <!-- These SCRIMMAGE simulated sensors can not support custom location settings on the vehicle body or using multiple of each per vehicle unlike AirSim sensors.-->
     <!-- CAUTION: You can not use get_imu_data="true" in the AirSim plugin above and the ROSIMUSensor plugin below at the same time.-->
     <!-- CAUTION: To use the ROSIMUSensor plugin below, get_imu_data="false" must be set in the AirSim plugin above, else you will receive an error.-->
-<!--    <sensor vehicle_name="robot1">ROSAltimeter</sensor>-->
-<!--    <sensor vehicle_name="robot1">ROSCompass</sensor>-->
-<!--    <sensor vehicle_name="robot1">ROSIMUSensor</sensor>-->
+    <sensor vehicle_name="robot1">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot1">ROSCompass</sensor>
+    <sensor vehicle_name="robot1">ROSIMUSensor</sensor>
 
 
     <!-- ROSAirSim Plugin -->
@@ -117,13 +120,13 @@
 
     <!-- Set ros_python to "true" if using ROS's python interface, "false" uses Image Transports ROS msg for images.-->
     <!-- Set ros_cartographer to "true" if using ROS Cartographer with Scrimmage/AirSim-->
-<!--    <autonomy vehicle_name="robot1"-->
-<!--              show_camera_images="false"-->
-<!--              pub_image_data="true"-->
-<!--              pub_lidar_data="true"-->
-<!--              pub_imu_data="true"-->
-<!--              ros_python="false"-->
-<!--              ros_cartographer="false">ROSAirSim</autonomy>-->
+    <autonomy vehicle_name="robot1"
+              show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true"
+              pub_imu_data="true"
+              ros_python="false"
+              ros_cartographer="false">ROSAirSim</autonomy>
 
 
     <!-- Straight Plugin -->
@@ -174,15 +177,18 @@
     <!-- lidar_acquisition_period determines the number of times LIDAR data is requested from AirSim per second -->
     <!-- imu_acquisition_period determines the number of times IMU data is requested from AirSim per second -->
     <!-- 0.1 => 1000ms/(0.1*1000ms) = 10 times per second -->
+
+    <!-- use_init_maneuver makes all aircraft perform a visual odometry initialization maneuver at the beginning of the mission -->
     <sensor airsim_ip="127.0.0.1"
             vehicle_name="robot2"
             save_airsim_data="true"
             get_image_data="true"
             get_lidar_data="true"
-            get_imu_data="true"
+            get_imu_data="false"
             image_acquisition_period="0.33"
             lidar_acquisition_period="0.1"
-            imu_acquisition_period="0.1">AirSimSensor</sensor>
+            imu_acquisition_period="0.1"
+            use_init_maneuver="true">AirSimSensor</sensor>
 
 
     <!-- SCRIMMAGE ROS Data Plugins -->
@@ -191,9 +197,9 @@
     <!-- These SCRIMMAGE simulated sensors can not support custom location settings on the vehicle body or using multiple of each per vehicle unlike AirSim sensors.-->
     <!-- CAUTION: You can not use get_imu_data="true" in the AirSim plugin above and the ROSIMUSensor plugin below at the same time.-->
     <!-- CAUTION: To use the ROSIMUSensor plugin below, get_imu_data="false" must be set in the AirSim plugin above, else you will receive an error.-->
-<!--    <sensor vehicle_name="robot2">ROSAltimeter</sensor>-->
-<!--    <sensor vehicle_name="robot2">ROSCompass</sensor>-->
-<!--    <sensor vehicle_name="robot2">ROSIMUSensor</sensor>-->
+    <sensor vehicle_name="robot2">ROSAltimeter</sensor>
+    <sensor vehicle_name="robot2">ROSCompass</sensor>
+    <sensor vehicle_name="robot2">ROSIMUSensor</sensor>
 
 
     <!-- ROSAirSim Plugin -->
@@ -208,13 +214,13 @@
 
     <!-- Set ros_python to "true" if using ROS's python interface, "false" uses Image Transports ROS msg for images.-->
     <!-- Set ros_cartographer to "true" if using ROS Cartographer with Scrimmage/AirSim-->
-<!--    <autonomy vehicle_name="robot2"-->
-<!--              show_camera_images="false"-->
-<!--              pub_image_data="true"-->
-<!--              pub_lidar_data="true"-->
-<!--              pub_imu_data="true"-->
-<!--              ros_python="false"-->
-<!--              ros_cartographer="false">ROSAirSim</autonomy>-->
+    <autonomy vehicle_name="robot2"
+              show_camera_images="false"
+              pub_image_data="true"
+              pub_lidar_data="true"
+              pub_imu_data="true"
+              ros_python="false"
+              ros_cartographer="false">ROSAirSim</autonomy>
 
 
     <!-- Straight Plugin -->

--- a/missions/quad-airsim-ex1.xml
+++ b/missions/quad-airsim-ex1.xml
@@ -3,7 +3,7 @@
 <runscript xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
     name="Straight flying">
 
-  <run start="0.0" end="100" dt="0.01"
+  <run start="0.0" end="1500" dt="0.01"
        time_warp="1"
        enable_gui="true"
        network_gui="false"
@@ -36,6 +36,14 @@
   <altitude_origin>300</altitude_origin>
   <show_origin>true</show_origin>
   <origin_length>10</origin_length>
+
+  <entity_interaction name="blue_boundary"
+                      type="cuboid"
+                      lengths="50, 50, 50"
+                      center="25, 25, 0"
+                      color="0 0 255"
+                      id="1"
+                      team_id="1">Boundary</entity_interaction>
 
   <entity_interaction>SimpleCollision</entity_interaction>
   <entity_interaction>ROSClockServer</entity_interaction>
@@ -94,7 +102,7 @@
             image_acquisition_period="0.33"
             lidar_acquisition_period="0.1"
             imu_acquisition_period="0.1"
-            use_init_maneuver="true">AirSimSensor</sensor>
+            use_init_maneuver="false">AirSimSensor</sensor>
 
 
     <!-- SCRIMMAGE ROS Data Plugins-->
@@ -128,11 +136,20 @@
               ros_python="false"
               ros_cartographer="false">ROSAirSim</autonomy>
 
-
     <!-- Straight Plugin -->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
     <!-- show_camera_images shows AirSim images in windows during simulation. -->
     <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
-    <autonomy show_camera_images="true">Straight</autonomy>
+<!--    <autonomy show_camera_images="true">Straight</autonomy>-->
+
+    <!-- Square Plugin -->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true"
+              use_init_maneuver="false"
+              sq_side_length_m="50"
+              speed="21">Square</autonomy>
 
     <motion_model motion_model_sets_yaw="false"
                   sim_copter_orientation="true"
@@ -188,7 +205,7 @@
             image_acquisition_period="0.33"
             lidar_acquisition_period="0.1"
             imu_acquisition_period="0.1"
-            use_init_maneuver="true">AirSimSensor</sensor>
+            use_init_maneuver="false">AirSimSensor</sensor>
 
 
     <!-- SCRIMMAGE ROS Data Plugins -->
@@ -224,9 +241,19 @@
 
 
     <!-- Straight Plugin -->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
     <!-- show_camera_images shows AirSim images in windows during simulation. -->
     <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
-    <autonomy show_camera_images="true">Straight</autonomy>
+<!--    <autonomy show_camera_images="true">Straight</autonomy>-->
+
+    <!-- Square Plugin -->
+    <!-- Only leave one uncommented: Straight Plugin or Square Plugin -->
+    <!-- show_camera_images shows AirSim images in windows during simulation. -->
+    <!-- Make sure "get_image_data" is set "true" in AirSimSensor above before use. -->
+    <autonomy show_camera_images="true"
+              use_init_maneuver="false"
+              sq_side_length_m="50"
+              speed="21">Square</autonomy>
 
     <motion_model motion_model_sets_yaw="false"
                   sim_copter_orientation="true"

--- a/src/entity/EntityPlugin.cpp
+++ b/src/entity/EntityPlugin.cpp
@@ -91,6 +91,7 @@ void EntityPlugin::draw_shape(scrimmage_proto::ShapePtr s) {
         // and a random number.
         std::string str = name() + std::to_string(parent_->id().id())
                 + std::to_string(time_->t())
+                + std::to_string(parent_->random()->rng_uniform())
                 + std::to_string(parent_->random()->rng_uniform());
 
         std::size_t hash_id = std::hash<std::string>{}(str);

--- a/src/plugins/autonomy/Square/CMakeLists.txt
+++ b/src/plugins/autonomy/Square/CMakeLists.txt
@@ -1,0 +1,42 @@
+#--------------------------------------------------------
+# Library Creation
+#--------------------------------------------------------
+SET (LIBRARY_NAME Square_plugin)
+SET (LIB_MAJOR 0)
+SET (LIB_MINOR 0)
+SET (LIB_RELEASE 1)
+
+file(GLOB SRCS *.cpp)
+
+ADD_LIBRARY(${LIBRARY_NAME} SHARED
+  ${SRCS}
+  )
+
+TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
+  Boundary_plugin
+  scrimmage-core
+  )
+
+if (OpenCV_FOUND)
+  TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
+    scrimmage-opencv
+    )
+endif()
+
+SET (_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})
+
+set_target_properties(${LIBRARY_NAME} PROPERTIES
+  SOVERSION ${LIB_MAJOR}
+  VERSION ${_soversion}
+  LIBRARY_OUTPUT_DIRECTORY ${PROJECT_PLUGIN_LIBS_DIR}
+  )
+
+install(TARGETS ${LIBRARY_NAME}
+  # IMPORTANT: Add the library to the "export-set"
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib/${PROJECT_NAME}/plugin_libs
+)
+
+# Push up the PROJECT_PLUGINS variable
+set(PROJECT_PLUGINS ${PROJECT_PLUGINS} ${LIBRARY_NAME} PARENT_SCOPE)

--- a/src/plugins/autonomy/Square/Square.cpp
+++ b/src/plugins/autonomy/Square/Square.cpp
@@ -204,6 +204,7 @@ std::deque<State> Square::get_init_maneuver_positions() {
 
 //        for (auto state : man_positions) {
 //            cout << state.pos()(0) << ", " << state.pos()(1) << ", " << state.pos()(2) << "\n" << endl;
+//            // cout << state.quat().yaw() << endl;
 //        }
 
         return man_positions;
@@ -376,6 +377,7 @@ bool Square::step_autonomy(double t, double dt) {
         next_goal_ = goal2_;
         prev_diff_ = {0,0,0};
         cout << "init maneuver finished at time: " << t << endl;
+        state_->set_quat(init_man_goal_quat_);
     }
 
     // Publish the Init Maneuver Status to send to AirSimSensor
@@ -412,11 +414,15 @@ bool Square::step_autonomy(double t, double dt) {
         // do not count z in the velocity normalization
         v(2) = 0.0;
         // heading should stay facing the original heading
-        noisy_state_.set_quat(init_man_goal_quat_);
+        state_->set_quat(init_man_goal_quat_);
         prev_diff_ = diff;
 
     } else {
         // if not performing init maneuver
+
+        // make sure state us using the correct yaw
+        // Quaternion quat_now = noisy_state_.quat();
+        // quat_now
 
         // check if we have completed this side
         // float distance = sqrt(pow((init_goal_(0) - state_->pos()(0)), 2) + pow((init_goal_(1) - state_->pos()(1)), 2));
@@ -488,10 +494,13 @@ bool Square::step_autonomy(double t, double dt) {
         prev_diff_ = diff;
     }
 
+    // cout << "yaw: " << noisy_state_.quat().yaw() << endl;
+
     ///////////////////////////////////////////////////////////////////////////
     // Convert desired velocity to desired speed, heading, and pitch controls
     ///////////////////////////////////////////////////////////////////////////
     double heading = Angles::angle_2pi(atan2(v(1), v(0)));
+    // cout << "hdn: " << heading << endl;
     vars_.output(desired_alt_idx_, altitude);
     vars_.output(desired_speed_idx_, v.norm());
     vars_.output(desired_heading_idx_, heading);

--- a/src/plugins/autonomy/Square/Square.cpp
+++ b/src/plugins/autonomy/Square/Square.cpp
@@ -375,7 +375,7 @@ bool Square::step_autonomy(double t, double dt) {
         goal_ = goal1_;
         next_goal_ = goal2_;
         prev_diff_ = {0,0,0};
-        cout << "init maneuver finished" << endl;
+        cout << "init maneuver finished at time: " << t << endl;
     }
 
     // Publish the Init Maneuver Status to send to AirSimSensor

--- a/src/plugins/autonomy/Square/Square.cpp
+++ b/src/plugins/autonomy/Square/Square.cpp
@@ -88,16 +88,15 @@ std::deque<State> Square::get_init_maneuver_positions() {
         State init_state(*state);
         State current_state(*state);
         // man_positions.push_back(current_state);
-//        double delta = 0.05;
-        double delta = 1.0;
 
         // Rise up to 5 meters above the starting position
 //        for (double i=0.0; i<5.0; i+=delta) {
 //            current_state.pos()(2) = current_state.pos()(2) + delta;
 //            man_positions.push_back(current_state);
 //        }
-        cout << "starting_state: " <<  current_state.pos() << endl;
-        current_state.pos()(2) = current_state.pos()(2) + 5.0;
+        // cout << "starting_state: " <<  current_state.pos() << endl;
+        // add 5m in altitude
+        // current_state.pos()(2) = current_state.pos()(2) + 5.0;
         man_positions.push_back(current_state);
 
 //        // repeat the below right-left movements 1 times
@@ -121,12 +120,12 @@ std::deque<State> Square::get_init_maneuver_positions() {
 //                man_positions.push_back(current_state);
 //            }
 //        }
-
-        current_state.pos()(1) = current_state.pos()(1) + 5.0;
+        // move left - right
+        current_state.pos()(1) = current_state.pos()(1) + 4.0;
         man_positions.push_back(current_state);
-        current_state.pos()(1) = current_state.pos()(1) - 10.0;
+        current_state.pos()(1) = current_state.pos()(1) - 8.0;
         man_positions.push_back(current_state);
-        current_state.pos()(1) = current_state.pos()(1) + 5.0;
+        current_state.pos()(1) = current_state.pos()(1) + 4.0;
         man_positions.push_back(current_state);
 
 //        // repeat the below up-down movements 3 times
@@ -150,12 +149,12 @@ std::deque<State> Square::get_init_maneuver_positions() {
 //                man_positions.push_back(current_state);
 //            }
 //        }
-
-        current_state.pos()(2) = current_state.pos()(2) + 5.0;
+        // move up-down
+        current_state.pos()(2) = current_state.pos()(2) + 4.0;
         man_positions.push_back(current_state);
-        current_state.pos()(2) = current_state.pos()(2) - 10.0;
+        current_state.pos()(2) = current_state.pos()(2) - 8.0;
         man_positions.push_back(current_state);
-        current_state.pos()(2) = current_state.pos()(2) + 5.0;
+        current_state.pos()(2) = current_state.pos()(2) + 4.0;
         man_positions.push_back(current_state);
 
 //        // move in a 4mx2m rectangle parallel to the ground 3 times
@@ -186,16 +185,16 @@ std::deque<State> Square::get_init_maneuver_positions() {
 //                man_positions.push_back(current_state);
 //            }
 //        }
-
-        current_state.pos()(1) = current_state.pos()(1) + 5.0;
+        // move in a rectangle - right, forward, left, backward, right
+        current_state.pos()(1) = current_state.pos()(1) + 4.0;
         man_positions.push_back(current_state);
-        current_state.pos()(0) = current_state.pos()(0) + 5.0;
+        current_state.pos()(0) = current_state.pos()(0) + 4.0;
         man_positions.push_back(current_state);
-        current_state.pos()(1) = current_state.pos()(1) - 10.0;
+        current_state.pos()(1) = current_state.pos()(1) - 8.0;
         man_positions.push_back(current_state);
-        current_state.pos()(0) = current_state.pos()(0) - 5.0;
+        current_state.pos()(0) = current_state.pos()(0) - 4.0;
         man_positions.push_back(current_state);
-        current_state.pos()(1) = current_state.pos()(1) + 5.0;
+        current_state.pos()(1) = current_state.pos()(1) + 4.0;
         man_positions.push_back(current_state);
 
         // place back at beginning for Straight Plugin
@@ -203,9 +202,9 @@ std::deque<State> Square::get_init_maneuver_positions() {
         man_positions.push_back(init_state);
         man_positions.push_back(init_state);
 
-        for (auto state : man_positions) {
-            cout << state.pos()(0) << ", " << state.pos()(1) << ", " << state.pos()(2) << "\n" << endl;
-        }
+//        for (auto state : man_positions) {
+//            cout << state.pos()(0) << ", " << state.pos()(1) << ", " << state.pos()(2) << "\n" << endl;
+//        }
 
         return man_positions;
 }
@@ -215,41 +214,31 @@ void Square::init(std::map<std::string, std::string> &params) {
     show_camera_images_ = scrimmage::get<bool>("show_camera_images", params, false);
     save_camera_images_ = scrimmage::get<bool>("save_camera_images", params, false);
     sq_side_length_m_ = scrimmage::get<double>("sq_side_length_m", params, 100);
+    start_corner_turn_ = scrimmage::get<double>("start_corner_turn", params, 10);
 
-    // Project goal in front...
-//    Eigen::Vector3d rel_pos = Eigen::Vector3d::UnitX()*1e6;
-//    Eigen::Vector3d unit_vector = rel_pos.normalized();
-//    unit_vector = state_->quat().rotate(unit_vector);
-//    goal_ = state_->pos() + unit_vector * rel_pos.norm();
-//    goal_(2) = state_->pos()(2);
-
-    cout << "speed: " << speed_ << endl;
-
+    // Save the initial starting position
+    init_goal_ = state_->pos();
     // initialize the corner locations of the square
+    cout << "[SquareAutonomy] Square Corner Locations:" << endl;
     // positve x direction
     goal1_ = state_->pos();
     goal1_(0) = goal1_(0) + sq_side_length_m_;
-    cout << "goal1: " << goal1_ << endl;
+    cout << "goal1: " << goal1_(0) << ", " << goal1_(1) << ", " << goal1_(2) << endl;
     // positve y direction
     goal2_ = goal1_;
     goal2_(1) = goal2_(1) + sq_side_length_m_;
-    cout << "goal2: " << goal2_ << endl;
+    cout << "goal2: " << goal2_(0) << ", " << goal2_(1) << ", " << goal2_(2) << endl;
     // negative x direction
     goal3_ = goal2_;
     goal3_(0) = goal3_(0) - sq_side_length_m_;
-    cout << "goal3: " << goal3_ << endl;
+    cout << "goal3: " << goal3_(0) << ", " << goal3_(1) << ", " << goal3_(2) << endl;
     // negative y direction
     goal4_ = goal3_;
     goal4_(1) = goal4_(1) - sq_side_length_m_;
-    cout << "goal4: " << goal4_ << endl;
-
-    // goal_ = goal1_;
+    cout << "goal4: " << goal4_(0) << ", " << goal4_(1) << ", " << goal4_(2) << endl;
 
     // Save the initial starting position
-    // desired_z_ = state_->pos()(2);
-    init_goal_ = state_->pos();
-    noisy_state_ = *state_;
-    cout << "original init_goal_: " << init_goal_ << endl;
+    // cout << "starting position: " << init_goal_ << endl;
 
     // Register the desired_z parameter with the parameter server
     auto param_cb = [&](const double &desired_z) {
@@ -285,25 +274,23 @@ void Square::init(std::map<std::string, std::string> &params) {
 
     // If using an initialization maneuver, then compile the position vector
     use_init_maneuver_ = sc::get<bool>("use_init_maneuver", params, "false");
+    // create an init maneuver publisher
+    init_maneuver_pub_ = advertise("LocalNetwork", "InitManeuver");
+    init_maneuver_finished_ = true;
     if (use_init_maneuver_) {
         man_positions_ = get_init_maneuver_positions();
-        cout << "[Square] Start VO Initialization Maneuver." << endl;
-    }
+        init_maneuver_finished_ = false;
+        cout << "[SquareAutonomy] Start VO Initialization Maneuver." << endl;
 
-    if (use_init_maneuver_) {
         State next_state = man_positions_.front();
         man_positions_.pop_front();
         init_man_goal_pos_ = next_state.pos();
         init_man_goal_quat_ = next_state.quat();
-        // goal_ = man_positions_;
+
     } else {
         goal_ = goal1_;
+        next_goal_ = goal2_;
     }
-
-//    enable_boundary_control_ = get<bool>("enable_boundary_control", params, false);
-//
-//    auto bd_cb = [&](auto &msg) {boundary_ = sci::Boundary::make_boundary(msg->data);};
-//    subscribe<sp::Shape>("GlobalNetwork", "Boundary", bd_cb);
 
     auto state_cb = [&](auto &msg) {
         noisy_state_set_ = true;
@@ -366,11 +353,6 @@ void Square::init(std::map<std::string, std::string> &params) {
     subscribe<sc::sensor::ContactBlobCameraType>("LocalNetwork", "ContactBlobCamera", blob_cb);
 #endif
 
-//    gen_ents_ = sc::get("generate_entities", params, gen_ents_);
-//    if (gen_ents_) {
-//        pub_gen_ents_ = advertise("GlobalNetwork", "GenerateEntity");
-//    }
-
     desired_alt_idx_ = vars_.declare(VariableIO::Type::desired_altitude, VariableIO::Direction::Out);
     desired_speed_idx_ = vars_.declare(VariableIO::Type::desired_speed, VariableIO::Direction::Out);
     desired_heading_idx_ = vars_.declare(VariableIO::Type::desired_heading, VariableIO::Direction::Out);
@@ -383,127 +365,62 @@ bool Square::step_autonomy(double t, double dt) {
         noisy_state_ = *state_;
     }
 
-//    if (boundary_ != nullptr && enable_boundary_control_) {
-//        if (!boundary_->contains(noisy_state_.pos())) {
-//            // Project goal through center of boundary
-//            Eigen::Vector3d center = boundary_->center();
-//            center(2) = noisy_state_.pos()(2); // maintain altitude
-//            Eigen::Vector3d diff = center - noisy_state_.pos();
-//            goal_ = noisy_state_.pos() + diff.normalized() * 1e6;
-//        }
-//    }
-
+    Eigen::Vector3d current_goal;
     Eigen::Vector3d diff;
     Eigen::Vector3d v;
     double altitude = goal_(2);
-    // double heading = init_man_goal_quat_.yaw();
 
-    // cout << "HERE" << endl;
-
-    if (man_positions_.size() == 0 && use_init_maneuver_) {
+    if (man_positions_.size() == 0 && use_init_maneuver_ && init_maneuver_finished_ == false) {
         init_maneuver_finished_ = true;
-        // goal_ = init_goal_;
         goal_ = goal1_;
+        next_goal_ = goal2_;
         prev_diff_ = {0,0,0};
         cout << "init maneuver finished" << endl;
     }
 
-    if (!init_maneuver_finished_ && use_init_maneuver_) {
+    // Publish the Init Maneuver Status to send to AirSimSensor
+    // This is necessary to prevent the quadcopter from rotating during the init maneuver
+    // for Visual Odometry init maneuver we need the camera to stay facing forward
+    auto msg = std::make_shared<sc::Message<InitManeuverType>>();
+    msg->data.active = !init_maneuver_finished_;
+    init_maneuver_pub_->publish(msg);
 
+    if (!init_maneuver_finished_ && use_init_maneuver_) {
         // Pop a state off the front of man_positions_ vector and delete the element
         float distance = sqrt(pow((init_man_goal_pos_(0) - noisy_state_.pos()(0)), 2) + pow((init_man_goal_pos_(1) - noisy_state_.pos()(1)), 2) + pow((init_man_goal_pos_(2) - noisy_state_.pos()(2)), 2));
-        cout << "DISTANCE: " << distance << endl;
-        if (distance < 1.0) {
+        if (distance < 0.5) {
             State next_state = man_positions_.front();
             man_positions_.pop_front();
-            // cout << "remaining man_pos: " << man_positions_.size() << endl;
             init_man_goal_pos_ = next_state.pos();
-            init_man_goal_quat_ = next_state.quat();
             v = {0, 0, 0};
             altitude = init_man_goal_pos_(2);
             prev_diff_ = {0, 0, 0};
-        } else {
-
-            cout << "remaining man_pos: " << man_positions_.size() << endl;
-            cout << "next_state: " << init_man_goal_pos_ << endl;
-            cout << "current_state: " << noisy_state_.pos() << endl;
-            // create desired goal and velocity
-    //        diff = init_man_goal_pos_ - noisy_state_.pos();
-    //        v = 5.0 * diff.normalized();
-    //        // heading = init_man_goal_quat_.yaw();
-    //        altitude = init_man_goal_pos_(2);
-
-            // create desired goal and velocity
-            // 1.0, 1.0 - bad overshoot
-            // 0.5, 50 is good
-            // 0.4/50 and 0.5/60 and 0.5/55 gives dead stop at corners
-            double kp = 0.4;
-            double kd = 50.0;
-            diff = init_man_goal_pos_ - noisy_state_.pos();
-            cout << "diff: " << diff << endl;
-            // v = speed_ * (diff - (diff-prev_diff);
-            // v = 1.0 * (kp*diff.normalized() + kd*(diff.normalized() - prev_diff_.normalized()));
-            v = 3.0 * (kp*diff + kd*(diff - prev_diff_));
-
         }
 
-//        cout << "remaining man_pos: " << man_positions_.size() << endl;
-//        cout << "next_state: " << init_man_goal_pos_ << endl;
-//        cout << "current_state: " << noisy_state_.pos() << endl;
-//        // create desired goal and velocity
-////        diff = init_man_goal_pos_ - noisy_state_.pos();
-////        v = 5.0 * diff.normalized();
-////        // heading = init_man_goal_quat_.yaw();
-////        altitude = init_man_goal_pos_(2);
-//
-//        // create desired goal and velocity
-//        // 1.0, 1.0 - bad overshoot
-//        // 0.5, 50 is pretty good so is 0.6, 60 - maybe a meter of overshoot, 0.4 40 gives more overshoot
-//        // 0.4/50 and 0.5/60 and 0.5/55 gives dead stop at corners
-//        double kp = 0.5;
-//        double kd = 50.0;
-//        diff = init_man_goal_pos_ - noisy_state_.pos();
-//        cout << "diff: " << diff << endl;
-//        // v = speed_ * (diff - (diff-prev_diff);
-//        // v = 1.0 * (kp*diff.normalized() + kd*(diff.normalized() - prev_diff_.normalized()));
-//        v = 3.0 * (kp*diff + kd*(diff - prev_diff_));
-
-////        // solution that is different for individual axis?
-//        Eigen::Vector3d kp = diff.normalized();
-//        Eigen::Vector3d kd = (diff - prev_diff_).normalized();
-//        v(0) = speed_ * (kp(0)*diff(0) + kd(0)*(diff(0) - prev_diff_(0)));
-//        v(1) = speed_ * (kp(1)*diff(1) + kd(1)*(diff(1) - prev_diff_(1)));
-//        v(2) = speed_ * (kp(2)*diff(2) + kd(2)*(diff(2) - prev_diff_(2)));
-
-        altitude = init_man_goal_pos_(2);
-        cout << "V: " << v << endl;
-        cout << "proportional: " << diff << endl;
-        cout << "derivative: " << diff - prev_diff_ << endl;
-        cout << "altitude: " << altitude << endl;
+        // PD Controller
+        // create desired goal and velocity
+        // 1.0, 1.0 - bad overshoot
+        // 0.5, 50 is good
+        // 0.4/50 and 0.5/60 and 0.5/55 gives dead stop at corners
+        double kp = 0.6;
+        double kd = 60.0;
+        double init_man_speed = 5.0;
+        diff = init_man_goal_pos_ - noisy_state_.pos();
+        v = init_man_speed * (kp*diff + kd*(diff - prev_diff_));
+        // calculate the new desired altitude
+        altitude = noisy_state_.pos()(2) + v(2)*dt;
+        // do not count z in the velocity normalization
+        v(2) = 0.0;
+        // heading should stay facing the original heading
+        noisy_state_.set_quat(init_man_goal_quat_);
         prev_diff_ = diff;
 
     } else {
-
-//        // if init maneuver was used, start the drones at the starting point
-//        if(square_side_ == 0) {
-//            if(use_init_maneuver_) {
-//                float distance = sqrt(pow((goal_(0) - noisy_state_.pos()(0)), 2) + pow((goal_(1) - noisy_state_.pos()(1)), 2));
-//                if (distance < 5) {
-//                    square_side_ += 1;
-//                    goal_ = goal1_;
-//                }
-//            }
-//            else{
-//                square_side_ += 1;
-//            }
-//        }
+        // if not performing init maneuver
 
         // check if we have completed this side
-        float distance = sqrt(pow((init_goal_(0) - state_->pos()(0)), 2) + pow((init_goal_(1) - state_->pos()(1)), 2));
-//        cout << "distance: " << distance << endl;
-//        cout << "sq_side_length_m_: " << sq_side_length_m_ << endl;
-//        cout << "square_side_: " << square_side_ << endl;
-//        cout << "position: " << state_->pos()<< endl;
+        // float distance = sqrt(pow((init_goal_(0) - state_->pos()(0)), 2) + pow((init_goal_(1) - state_->pos()(1)), 2));
+        float distance = sqrt(pow((init_goal_(0) - noisy_state_.pos()(0)), 2) + pow((init_goal_(1) - noisy_state_.pos()(1)), 2));
         if (distance >= sq_side_length_m_ && square_side_ > 0){
             // update which side of the square we are on.
             square_side_ += 1;
@@ -514,60 +431,61 @@ bool Square::step_autonomy(double t, double dt) {
             switch(current_side) {
                 case 1:
                   {
-                      // cout << '1' << endl; // prints "1"
-                      // Project goal in front...
                       // Move in positive X direction
                         goal_ = goal1_;
+                        next_goal_ = goal2_;
                       break;
                   }
                 case 2 :
                   {
-                      // cout << '2' << endl;
-                      // Project goal in front...
                       // Move in positive Y direction
                       goal_ = goal2_;
+                      next_goal_ = goal3_;
                       break;
                   }
                 case 3:
                   {
-                      // cout << '3' << endl;
-                      // Project goal in front...
                       // Move in negative X direction
                       goal_ = goal3_;
+                      next_goal_ = goal4_;
                       break;
                   }
                 case 0:
                   {
-                      // cout << '4' << endl;
-                      // Project goal in front...
                       // Move in negative Y direction
                       goal_ = goal4_;
+                      next_goal_ = goal1_;
                       break;
                   }
             }
-            cout << "goal: " << goal_ << endl;
+        } // if distance
+
+        // Parametric Path Planning
+        // heading should turn slowly toward the next corner as it approaches a corner in order to keep the camera on track
+        current_goal = goal_;
+        // if distance is less than 10 to the upcoming corner start adding in influence for the next goal
+        // cout << (sq_side_length_m_ - distance) << endl;
+        if ((sq_side_length_m_ - distance) < start_corner_turn_) {
+            // influence (btw 0 and 1) will increase as the quadcopter gets closer to the corner
+            double influence = (start_corner_turn_ - (sq_side_length_m_ - distance)) / start_corner_turn_;
+            // average the goal position between the upcoming corner and the next corner as the quadcopter gets closer
+            current_goal = (current_goal * (1.0 - influence)) + (next_goal_ * influence);
         }
 
-     // create desired goal and velocity
-     // 1.0, 1.0 - bad overshoot
-     // 0.5, 50 is pretty good so is 0.6, 60 - maybe a meter of overshoot, 0.4 40 gives more overshoot
-     // 0.4/50 and 0.5/60 and 0.5/55 gives dead stop at corners
+        // create desired goal and velocity
+        // 1.0, 1.0 - bad overshoot
+        // 0.5, 50 is pretty good so is 0.6, 60 - maybe a meter of overshoot, 0.4 40 gives more overshoot
+        // 0.4/50 and 0.5/60 and 0.5/55 gives dead stop at corners
+        double kp = 0.6;
+        double kd = 60;
+        diff = current_goal - noisy_state_.pos();
+        v = speed_ * (kp*diff + kd*(diff - prev_diff_));
+        // calculate the new desired altitude
+        altitude = noisy_state_.pos()(2) + v(2)*dt;
+        // do not count z in the velocity normalization
+        v(2) = 0.0;
 
-    double kp = 0.6;
-    double kd = 60;
-    diff = goal_ - noisy_state_.pos();
-    cout << "diff: " << diff << endl;
-    // v * (diff - (diff-prev_diff)
-    // v = speed_ * (kp*diff.normalized() + kd*(diff.normalized() - prev_diff_.normalized()));
-    v = speed_ * (kp*diff + kd*(diff - prev_diff_));
-    cout << "V: " << v << endl;
-    cout << "proportional: " << diff << endl;
-    cout << "derivative: " << diff - prev_diff_ << endl;
-
-    altitude = goal_(2);
-
-    prev_diff_ = diff;
-    // heading = Angles::angle_2pi(atan2(v(1), v(0)));
+        prev_diff_ = diff;
     }
 
     ///////////////////////////////////////////////////////////////////////////

--- a/src/plugins/autonomy/Square/Square.cpp
+++ b/src/plugins/autonomy/Square/Square.cpp
@@ -89,121 +89,50 @@ std::deque<State> Square::get_init_maneuver_positions() {
         State current_state(*state);
         // man_positions.push_back(current_state);
 
-        // Rise up to 5 meters above the starting position
-//        for (double i=0.0; i<5.0; i+=delta) {
-//            current_state.pos()(2) = current_state.pos()(2) + delta;
-//            man_positions.push_back(current_state);
-//        }
         // cout << "starting_state: " <<  current_state.pos() << endl;
         // add 5m in altitude
-        // current_state.pos()(2) = current_state.pos()(2) + 5.0;
+        current_state.pos()(2) = current_state.pos()(2) + 3.0;
         man_positions.push_back(current_state);
 
-//        // repeat the below right-left movements 1 times
-//        for (int repeat = 0; repeat<1; repeat++){
-//            // move 2 meters to the right, back to the center
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(1) = current_state.pos()(1) + delta;;
-//                man_positions.push_back(current_state);
-//            }
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(1) = current_state.pos()(1) - delta;
-//                man_positions.push_back(current_state);
-//            }
-//            // move 2 meters to the left, back to the center
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(1) = current_state.pos()(1) - delta;
-//                man_positions.push_back(current_state);
-//            }
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(1) = current_state.pos()(1) + delta;
-//                man_positions.push_back(current_state);
-//            }
-//        }
         // move left - right
-        current_state.pos()(1) = current_state.pos()(1) + 4.0;
+        current_state.pos()(1) = current_state.pos()(1) + 3.0;
         man_positions.push_back(current_state);
-        current_state.pos()(1) = current_state.pos()(1) - 8.0;
+        current_state.pos()(1) = current_state.pos()(1) - 6.0;
         man_positions.push_back(current_state);
-        current_state.pos()(1) = current_state.pos()(1) + 4.0;
+        current_state.pos()(1) = current_state.pos()(1) + 3.0;
         man_positions.push_back(current_state);
 
-//        // repeat the below up-down movements 3 times
-//        for (int repeat = 0; repeat<1; repeat++){
-//            // move 1 meter up, back to the center
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(2) = current_state.pos()(2) + delta;
-//                man_positions.push_back(current_state);
-//            }
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(2) = current_state.pos()(2) - delta;
-//                man_positions.push_back(current_state);
-//            }
-//            // move 1 meter down, back to the center
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(2) = current_state.pos()(2) - delta;
-//                man_positions.push_back(current_state);
-//            }
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(2) = current_state.pos()(2) + delta;
-//                man_positions.push_back(current_state);
-//            }
-//        }
         // move up-down
-        current_state.pos()(2) = current_state.pos()(2) + 4.0;
+        current_state.pos()(2) = current_state.pos()(2) + 2.0;
         man_positions.push_back(current_state);
-        current_state.pos()(2) = current_state.pos()(2) - 8.0;
+        current_state.pos()(2) = current_state.pos()(2) - 4.0;
         man_positions.push_back(current_state);
-        current_state.pos()(2) = current_state.pos()(2) + 4.0;
+        current_state.pos()(2) = current_state.pos()(2) + 2.0;
         man_positions.push_back(current_state);
 
-//        // move in a 4mx2m rectangle parallel to the ground 3 times
-//        for (int repeat = 0; repeat<1; repeat++){
-//            // move 1 meter in the +y direction
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(1) = current_state.pos()(1) + delta;
-//                man_positions.push_back(current_state);
-//            }
-//            // move 1 meter in the +x direction
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(0) = current_state.pos()(0) + delta;
-//                man_positions.push_back(current_state);
-//            }
-//            // move 2 meters in the -y direction
-//            for (double i=0.0; i<10.0; i+=delta) {
-//                current_state.pos()(1) = current_state.pos()(1) - delta;
-//                man_positions.push_back(current_state);
-//            }
-//            // move 1 meters in the -x direction
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(0) = current_state.pos()(0) - delta;
-//                man_positions.push_back(current_state);
-//            }
-//            // move 1 meter in the +y direction
-//            for (double i=0.0; i<5.0; i+=delta) {
-//                current_state.pos()(1) = current_state.pos()(1) + delta;
-//                man_positions.push_back(current_state);
-//            }
-//        }
         // move in a rectangle - right, forward, left, backward, right
-        current_state.pos()(1) = current_state.pos()(1) + 4.0;
+        current_state.pos()(1) = current_state.pos()(1) + 2.0;
         man_positions.push_back(current_state);
-        current_state.pos()(0) = current_state.pos()(0) + 4.0;
+        current_state.pos()(0) = current_state.pos()(0) + 2.0;
         man_positions.push_back(current_state);
-        current_state.pos()(1) = current_state.pos()(1) - 8.0;
+        current_state.pos()(1) = current_state.pos()(1) - 4.0;
         man_positions.push_back(current_state);
-        current_state.pos()(0) = current_state.pos()(0) - 4.0;
+        current_state.pos()(0) = current_state.pos()(0) - 2.0;
         man_positions.push_back(current_state);
-        current_state.pos()(1) = current_state.pos()(1) + 4.0;
+        current_state.pos()(1) = current_state.pos()(1) + 2.0;
         man_positions.push_back(current_state);
 
         // place back at beginning for Straight Plugin
+        // 5.0 = 0.14, 3.0 = -0.15, 0 = -1.9
         man_positions.push_back(init_state);
+        init_state.pos()(0) = init_state.pos()(0) + 5.0;
         man_positions.push_back(init_state);
+        init_state.pos()(0) = init_state.pos()(0) + 5.0;
         man_positions.push_back(init_state);
 
 //        for (auto state : man_positions) {
 //            cout << state.pos()(0) << ", " << state.pos()(1) << ", " << state.pos()(2) << "\n" << endl;
+//            // cout << state.quat().roll() << ", " << state.quat().pitch() << ", " << state.quat().yaw() << "\n" << endl;
 //            // cout << state.quat().yaw() << endl;
 //        }
 
@@ -219,6 +148,7 @@ void Square::init(std::map<std::string, std::string> &params) {
 
     // Save the initial starting position
     init_goal_ = state_->pos();
+    init_man_goal_quat_ = state_->quat();
     // initialize the corner locations of the square
     cout << "[SquareAutonomy] Square Corner Locations:" << endl;
     // positve x direction
@@ -360,6 +290,7 @@ void Square::init(std::map<std::string, std::string> &params) {
 }
 
 bool Square::step_autonomy(double t, double dt) {
+    sc::StatePtr &state_ = parent_->state_truth();
 
     // Read data from sensors...
     if (!noisy_state_set_) {
@@ -371,13 +302,18 @@ bool Square::step_autonomy(double t, double dt) {
     Eigen::Vector3d v;
     double altitude = goal_(2);
 
+    // If Init Maneuver is finished
     if (man_positions_.size() == 0 && use_init_maneuver_ && init_maneuver_finished_ == false) {
         init_maneuver_finished_ = true;
         goal_ = goal1_;
         next_goal_ = goal2_;
         prev_diff_ = {0,0,0};
         cout << "init maneuver finished at time: " << t << endl;
+        // Use the keep straight action one last time
+        parent_->state_truth()->set_quat(init_man_goal_quat_);
+        state_ = parent_->state_truth();
         state_->set_quat(init_man_goal_quat_);
+        noisy_state_ = *state_;
     }
 
     // Publish the Init Maneuver Status to send to AirSimSensor
@@ -385,8 +321,21 @@ bool Square::step_autonomy(double t, double dt) {
     // for Visual Odometry init maneuver we need the camera to stay facing forward
     auto msg = std::make_shared<sc::Message<InitManeuverType>>();
     msg->data.active = !init_maneuver_finished_;
+    msg->data.init_man_goal_quat = init_man_goal_quat_;
+    // if using init maneuver, keep the quadcopter at the same roll, pitch, yaw during the init maneuver
+    if (init_maneuver_finished_ == false) {
+            // Keep the quadcopter Straight
+            msg->data.stay_straight = true;
+            parent_->state_truth()->set_quat(init_man_goal_quat_);
+            state_ = parent_->state_truth();
+            state_->set_quat(init_man_goal_quat_);
+            noisy_state_ = *state_;
+    } else {
+        msg->data.stay_straight = false;
+    }
     init_maneuver_pub_->publish(msg);
 
+    // Perform Init Maneuver
     if (!init_maneuver_finished_ && use_init_maneuver_) {
         // Pop a state off the front of man_positions_ vector and delete the element
         float distance = sqrt(pow((init_man_goal_pos_(0) - noisy_state_.pos()(0)), 2) + pow((init_man_goal_pos_(1) - noisy_state_.pos()(1)), 2) + pow((init_man_goal_pos_(2) - noisy_state_.pos()(2)), 2));
@@ -413,19 +362,13 @@ bool Square::step_autonomy(double t, double dt) {
         altitude = noisy_state_.pos()(2) + v(2)*dt;
         // do not count z in the velocity normalization
         v(2) = 0.0;
-        // heading should stay facing the original heading
-        state_->set_quat(init_man_goal_quat_);
         prev_diff_ = diff;
 
     } else {
         // if not performing init maneuver
 
-        // make sure state us using the correct yaw
-        // Quaternion quat_now = noisy_state_.quat();
-        // quat_now
-
         // check if we have completed this side
-        // float distance = sqrt(pow((init_goal_(0) - state_->pos()(0)), 2) + pow((init_goal_(1) - state_->pos()(1)), 2));
+        // This gives us distance travelled from the start to the current location on the current side of the square
         float distance = sqrt(pow((init_goal_(0) - noisy_state_.pos()(0)), 2) + pow((init_goal_(1) - noisy_state_.pos()(1)), 2));
         if (distance >= sq_side_length_m_ && square_side_ > 0){
             // update which side of the square we are on.

--- a/src/plugins/autonomy/Square/Square.cpp
+++ b/src/plugins/autonomy/Square/Square.cpp
@@ -87,59 +87,76 @@ std::deque<State> Square::get_init_maneuver_positions() {
         sc::StatePtr &state = parent_->state_truth();
         State init_state(*state);
         State current_state(*state);
-        man_positions.push_back(current_state);
+        // man_positions.push_back(current_state);
 //        double delta = 0.05;
         double delta = 1.0;
 
         // Rise up to 5 meters above the starting position
-        for (double i=0.0; i<5.0; i+=delta) {
-            current_state.pos()(2) = current_state.pos()(2) + delta;
-            man_positions.push_back(current_state);
-        }
+//        for (double i=0.0; i<5.0; i+=delta) {
+//            current_state.pos()(2) = current_state.pos()(2) + delta;
+//            man_positions.push_back(current_state);
+//        }
+        cout << "starting_state: " <<  current_state.pos() << endl;
+        current_state.pos()(2) = current_state.pos()(2) + 5.0;
+        man_positions.push_back(current_state);
 
-        // repeat the below right-left movements 1 times
-        for (int repeat = 0; repeat<1; repeat++){
-            // move 2 meters to the right, back to the center
-            for (double i=0.0; i<5.0; i+=delta) {
-                current_state.pos()(1) = current_state.pos()(1) + delta;;
-                man_positions.push_back(current_state);
-            }
-            for (double i=0.0; i<5.0; i+=delta) {
-                current_state.pos()(1) = current_state.pos()(1) - delta;
-                man_positions.push_back(current_state);
-            }
-            // move 2 meters to the left, back to the center
-            for (double i=0.0; i<5.0; i+=delta) {
-                current_state.pos()(1) = current_state.pos()(1) - delta;
-                man_positions.push_back(current_state);
-            }
-            for (double i=0.0; i<5.0; i+=delta) {
-                current_state.pos()(1) = current_state.pos()(1) + delta;
-                man_positions.push_back(current_state);
-            }
-        }
+//        // repeat the below right-left movements 1 times
+//        for (int repeat = 0; repeat<1; repeat++){
+//            // move 2 meters to the right, back to the center
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(1) = current_state.pos()(1) + delta;;
+//                man_positions.push_back(current_state);
+//            }
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(1) = current_state.pos()(1) - delta;
+//                man_positions.push_back(current_state);
+//            }
+//            // move 2 meters to the left, back to the center
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(1) = current_state.pos()(1) - delta;
+//                man_positions.push_back(current_state);
+//            }
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(1) = current_state.pos()(1) + delta;
+//                man_positions.push_back(current_state);
+//            }
+//        }
 
-        // repeat the below up-down movements 3 times
-        for (int repeat = 0; repeat<1; repeat++){
-            // move 1 meter up, back to the center
-            for (double i=0.0; i<5.0; i+=delta) {
-                current_state.pos()(2) = current_state.pos()(2) + delta;
-                man_positions.push_back(current_state);
-            }
-            for (double i=0.0; i<5.0; i+=delta) {
-                current_state.pos()(2) = current_state.pos()(2) - delta;
-                man_positions.push_back(current_state);
-            }
-            // move 1 meter down, back to the center
-            for (double i=0.0; i<5.0; i+=delta) {
-                current_state.pos()(2) = current_state.pos()(2) - delta;
-                man_positions.push_back(current_state);
-            }
-            for (double i=0.0; i<5.0; i+=delta) {
-                current_state.pos()(2) = current_state.pos()(2) + delta;
-                man_positions.push_back(current_state);
-            }
-        }
+        current_state.pos()(1) = current_state.pos()(1) + 5.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(1) = current_state.pos()(1) - 10.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(1) = current_state.pos()(1) + 5.0;
+        man_positions.push_back(current_state);
+
+//        // repeat the below up-down movements 3 times
+//        for (int repeat = 0; repeat<1; repeat++){
+//            // move 1 meter up, back to the center
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(2) = current_state.pos()(2) + delta;
+//                man_positions.push_back(current_state);
+//            }
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(2) = current_state.pos()(2) - delta;
+//                man_positions.push_back(current_state);
+//            }
+//            // move 1 meter down, back to the center
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(2) = current_state.pos()(2) - delta;
+//                man_positions.push_back(current_state);
+//            }
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(2) = current_state.pos()(2) + delta;
+//                man_positions.push_back(current_state);
+//            }
+//        }
+
+        current_state.pos()(2) = current_state.pos()(2) + 5.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(2) = current_state.pos()(2) - 10.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(2) = current_state.pos()(2) + 5.0;
+        man_positions.push_back(current_state);
 
 //        // move in a 4mx2m rectangle parallel to the ground 3 times
 //        for (int repeat = 0; repeat<1; repeat++){
@@ -170,8 +187,25 @@ std::deque<State> Square::get_init_maneuver_positions() {
 //            }
 //        }
 
+        current_state.pos()(1) = current_state.pos()(1) + 5.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(0) = current_state.pos()(0) + 5.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(1) = current_state.pos()(1) - 10.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(0) = current_state.pos()(0) - 5.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(1) = current_state.pos()(1) + 5.0;
+        man_positions.push_back(current_state);
+
         // place back at beginning for Straight Plugin
         man_positions.push_back(init_state);
+        man_positions.push_back(init_state);
+        man_positions.push_back(init_state);
+
+        for (auto state : man_positions) {
+            cout << state.pos()(0) << ", " << state.pos()(1) << ", " << state.pos()(2) << "\n" << endl;
+        }
 
         return man_positions;
 }
@@ -181,10 +215,6 @@ void Square::init(std::map<std::string, std::string> &params) {
     show_camera_images_ = scrimmage::get<bool>("show_camera_images", params, false);
     save_camera_images_ = scrimmage::get<bool>("save_camera_images", params, false);
     sq_side_length_m_ = scrimmage::get<double>("sq_side_length_m", params, 100);
-
-    // record the initial state:
-    init_man_goal_pos_ = state_->pos();
-    init_man_goal_quat_ = state_->quat();
 
     // Project goal in front...
 //    Eigen::Vector3d rel_pos = Eigen::Vector3d::UnitX()*1e6;
@@ -213,11 +243,12 @@ void Square::init(std::map<std::string, std::string> &params) {
     goal4_(1) = goal4_(1) - sq_side_length_m_;
     cout << "goal4: " << goal4_ << endl;
 
-    goal_ = goal1_;
+    // goal_ = goal1_;
 
-    // Set the desired_z to our initial position.
+    // Save the initial starting position
     // desired_z_ = state_->pos()(2);
     init_goal_ = state_->pos();
+    noisy_state_ = *state_;
     cout << "original init_goal_: " << init_goal_ << endl;
 
     // Register the desired_z parameter with the parameter server
@@ -257,6 +288,16 @@ void Square::init(std::map<std::string, std::string> &params) {
     if (use_init_maneuver_) {
         man_positions_ = get_init_maneuver_positions();
         cout << "[Square] Start VO Initialization Maneuver." << endl;
+    }
+
+    if (use_init_maneuver_) {
+        State next_state = man_positions_.front();
+        man_positions_.pop_front();
+        init_man_goal_pos_ = next_state.pos();
+        init_man_goal_quat_ = next_state.quat();
+        // goal_ = man_positions_;
+    } else {
+        goal_ = goal1_;
     }
 
 //    enable_boundary_control_ = get<bool>("enable_boundary_control", params, false);
@@ -357,49 +398,105 @@ bool Square::step_autonomy(double t, double dt) {
     double altitude = goal_(2);
     // double heading = init_man_goal_quat_.yaw();
 
+    // cout << "HERE" << endl;
 
     if (man_positions_.size() == 0 && use_init_maneuver_) {
         init_maneuver_finished_ = true;
-        goal_ = init_goal_;
+        // goal_ = init_goal_;
+        goal_ = goal1_;
+        prev_diff_ = {0,0,0};
         cout << "init maneuver finished" << endl;
     }
 
     if (!init_maneuver_finished_ && use_init_maneuver_) {
 
         // Pop a state off the front of man_positions_ vector and delete the element
-        float distance = sqrt(pow((init_man_goal_pos_(0) - noisy_state_.pos()(0)), 2) + pow((init_man_goal_pos_(1) - noisy_state_.pos()(1)), 2));
-        if (distance < 0.05) {
+        float distance = sqrt(pow((init_man_goal_pos_(0) - noisy_state_.pos()(0)), 2) + pow((init_man_goal_pos_(1) - noisy_state_.pos()(1)), 2) + pow((init_man_goal_pos_(2) - noisy_state_.pos()(2)), 2));
+        cout << "DISTANCE: " << distance << endl;
+        if (distance < 1.0) {
             State next_state = man_positions_.front();
             man_positions_.pop_front();
             // cout << "remaining man_pos: " << man_positions_.size() << endl;
             init_man_goal_pos_ = next_state.pos();
             init_man_goal_quat_ = next_state.quat();
+            v = {0, 0, 0};
+            altitude = init_man_goal_pos_(2);
+            prev_diff_ = {0, 0, 0};
+        } else {
+
+            cout << "remaining man_pos: " << man_positions_.size() << endl;
+            cout << "next_state: " << init_man_goal_pos_ << endl;
+            cout << "current_state: " << noisy_state_.pos() << endl;
+            // create desired goal and velocity
+    //        diff = init_man_goal_pos_ - noisy_state_.pos();
+    //        v = 5.0 * diff.normalized();
+    //        // heading = init_man_goal_quat_.yaw();
+    //        altitude = init_man_goal_pos_(2);
+
+            // create desired goal and velocity
+            // 1.0, 1.0 - bad overshoot
+            // 0.5, 50 is good
+            // 0.4/50 and 0.5/60 and 0.5/55 gives dead stop at corners
+            double kp = 0.4;
+            double kd = 50.0;
+            diff = init_man_goal_pos_ - noisy_state_.pos();
+            cout << "diff: " << diff << endl;
+            // v = speed_ * (diff - (diff-prev_diff);
+            // v = 1.0 * (kp*diff.normalized() + kd*(diff.normalized() - prev_diff_.normalized()));
+            v = 3.0 * (kp*diff + kd*(diff - prev_diff_));
+
         }
 
-        cout << "remaining man_pos: " << man_positions_.size() << endl;
+//        cout << "remaining man_pos: " << man_positions_.size() << endl;
+//        cout << "next_state: " << init_man_goal_pos_ << endl;
+//        cout << "current_state: " << noisy_state_.pos() << endl;
+//        // create desired goal and velocity
+////        diff = init_man_goal_pos_ - noisy_state_.pos();
+////        v = 5.0 * diff.normalized();
+////        // heading = init_man_goal_quat_.yaw();
+////        altitude = init_man_goal_pos_(2);
+//
+//        // create desired goal and velocity
+//        // 1.0, 1.0 - bad overshoot
+//        // 0.5, 50 is pretty good so is 0.6, 60 - maybe a meter of overshoot, 0.4 40 gives more overshoot
+//        // 0.4/50 and 0.5/60 and 0.5/55 gives dead stop at corners
+//        double kp = 0.5;
+//        double kd = 50.0;
+//        diff = init_man_goal_pos_ - noisy_state_.pos();
+//        cout << "diff: " << diff << endl;
+//        // v = speed_ * (diff - (diff-prev_diff);
+//        // v = 1.0 * (kp*diff.normalized() + kd*(diff.normalized() - prev_diff_.normalized()));
+//        v = 3.0 * (kp*diff + kd*(diff - prev_diff_));
 
-        cout << "next_state: " << init_man_goal_pos_ << endl;
-        // create desired goal and velocity
-        diff = init_man_goal_pos_ - noisy_state_.pos();
-        v = 5.0 * diff.normalized();
-        // heading = init_man_goal_quat_.yaw();
+////        // solution that is different for individual axis?
+//        Eigen::Vector3d kp = diff.normalized();
+//        Eigen::Vector3d kd = (diff - prev_diff_).normalized();
+//        v(0) = speed_ * (kp(0)*diff(0) + kd(0)*(diff(0) - prev_diff_(0)));
+//        v(1) = speed_ * (kp(1)*diff(1) + kd(1)*(diff(1) - prev_diff_(1)));
+//        v(2) = speed_ * (kp(2)*diff(2) + kd(2)*(diff(2) - prev_diff_(2)));
+
         altitude = init_man_goal_pos_(2);
+        cout << "V: " << v << endl;
+        cout << "proportional: " << diff << endl;
+        cout << "derivative: " << diff - prev_diff_ << endl;
+        cout << "altitude: " << altitude << endl;
+        prev_diff_ = diff;
 
     } else {
 
-        // if init maneuver was used, start the drones at the starting point
-        if(square_side_ == 0) {
-            if(use_init_maneuver_) {
-                float distance = sqrt(pow((goal_(0) - noisy_state_.pos()(0)), 2) + pow((goal_(1) - noisy_state_.pos()(1)), 2));
-                if (distance < 5) {
-                    square_side_ += 1;
-                    goal_ = goal1_;
-                }
-            }
-            else{
-                square_side_ += 1;
-            }
-        }
+//        // if init maneuver was used, start the drones at the starting point
+//        if(square_side_ == 0) {
+//            if(use_init_maneuver_) {
+//                float distance = sqrt(pow((goal_(0) - noisy_state_.pos()(0)), 2) + pow((goal_(1) - noisy_state_.pos()(1)), 2));
+//                if (distance < 5) {
+//                    square_side_ += 1;
+//                    goal_ = goal1_;
+//                }
+//            }
+//            else{
+//                square_side_ += 1;
+//            }
+//        }
 
         // check if we have completed this side
         float distance = sqrt(pow((init_goal_(0) - state_->pos()(0)), 2) + pow((init_goal_(1) - state_->pos()(1)), 2));
@@ -452,9 +549,24 @@ bool Square::step_autonomy(double t, double dt) {
         }
 
      // create desired goal and velocity
+     // 1.0, 1.0 - bad overshoot
+     // 0.5, 50 is pretty good so is 0.6, 60 - maybe a meter of overshoot, 0.4 40 gives more overshoot
+     // 0.4/50 and 0.5/60 and 0.5/55 gives dead stop at corners
+
+    double kp = 0.6;
+    double kd = 60;
     diff = goal_ - noisy_state_.pos();
-    v = speed_ * diff.normalized();
+    cout << "diff: " << diff << endl;
+    // v * (diff - (diff-prev_diff)
+    // v = speed_ * (kp*diff.normalized() + kd*(diff.normalized() - prev_diff_.normalized()));
+    v = speed_ * (kp*diff + kd*(diff - prev_diff_));
+    cout << "V: " << v << endl;
+    cout << "proportional: " << diff << endl;
+    cout << "derivative: " << diff - prev_diff_ << endl;
+
     altitude = goal_(2);
+
+    prev_diff_ = diff;
     // heading = Angles::angle_2pi(atan2(v(1), v(0)));
     }
 

--- a/src/plugins/autonomy/Square/Square.cpp
+++ b/src/plugins/autonomy/Square/Square.cpp
@@ -1,0 +1,473 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Natalie Rakoski <natalie.rakoski@gtri.gatech.edu>
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @date 10 April 2021
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#include <scrimmage/common/Utilities.h>
+#include <scrimmage/common/Shape.h>
+#include <scrimmage/common/Time.h>
+#include <scrimmage/entity/Entity.h>
+#include <scrimmage/math/State.h>
+#include <scrimmage/math/StateWithCovariance.h>
+#include <scrimmage/math/Angles.h>
+#include <scrimmage/parse/ParseUtils.h>
+#include <scrimmage/plugin_manager/RegisterPlugin.h>
+#include <scrimmage/plugins/interaction/Boundary/BoundaryBase.h>
+#include <scrimmage/plugins/interaction/Boundary/Boundary.h>
+#include <scrimmage/proto/State.pb.h>
+#include <scrimmage/msgs/Event.pb.h>
+#include <scrimmage/pubsub/Message.h>
+#include <scrimmage/pubsub/Subscriber.h>
+#include <scrimmage/pubsub/Publisher.h>
+#include <scrimmage/sensor/Sensor.h>
+
+#if ENABLE_OPENCV == 1
+#include <scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCameraType.h>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#endif
+
+#if ENABLE_AIRSIM == 1
+#include <scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h>
+#endif
+
+#include <scrimmage/plugins/interaction/Boundary/Cuboid.h>
+
+namespace sc = scrimmage;
+namespace sp = scrimmage_proto;
+namespace sci = scrimmage::interaction;
+
+#include <scrimmage/plugins/autonomy/Square/Square.h>
+
+#define BOOST_NO_CXX11_SCOPED_ENUMS
+#include <boost/filesystem.hpp>
+#undef BOOST_NO_CXX11_SCOPED_ENUMS
+namespace fs = boost::filesystem;
+
+REGISTER_PLUGIN(scrimmage::Autonomy,
+                scrimmage::autonomy::Square,
+                Square_plugin)
+
+namespace scrimmage {
+namespace autonomy {
+
+std::deque<State> Square::get_init_maneuver_positions() {
+
+        std::deque<State> man_positions;
+
+        // get the starting position
+        sc::StatePtr &state = parent_->state_truth();
+        State init_state(*state);
+        State current_state(*state);
+        man_positions.push_back(current_state);
+//        double delta = 0.05;
+        double delta = 1.0;
+
+        // Rise up to 5 meters above the starting position
+        for (double i=0.0; i<5.0; i+=delta) {
+            current_state.pos()(2) = current_state.pos()(2) + delta;
+            man_positions.push_back(current_state);
+        }
+
+        // repeat the below right-left movements 1 times
+        for (int repeat = 0; repeat<1; repeat++){
+            // move 2 meters to the right, back to the center
+            for (double i=0.0; i<5.0; i+=delta) {
+                current_state.pos()(1) = current_state.pos()(1) + delta;;
+                man_positions.push_back(current_state);
+            }
+            for (double i=0.0; i<5.0; i+=delta) {
+                current_state.pos()(1) = current_state.pos()(1) - delta;
+                man_positions.push_back(current_state);
+            }
+            // move 2 meters to the left, back to the center
+            for (double i=0.0; i<5.0; i+=delta) {
+                current_state.pos()(1) = current_state.pos()(1) - delta;
+                man_positions.push_back(current_state);
+            }
+            for (double i=0.0; i<5.0; i+=delta) {
+                current_state.pos()(1) = current_state.pos()(1) + delta;
+                man_positions.push_back(current_state);
+            }
+        }
+
+        // repeat the below up-down movements 3 times
+        for (int repeat = 0; repeat<1; repeat++){
+            // move 1 meter up, back to the center
+            for (double i=0.0; i<5.0; i+=delta) {
+                current_state.pos()(2) = current_state.pos()(2) + delta;
+                man_positions.push_back(current_state);
+            }
+            for (double i=0.0; i<5.0; i+=delta) {
+                current_state.pos()(2) = current_state.pos()(2) - delta;
+                man_positions.push_back(current_state);
+            }
+            // move 1 meter down, back to the center
+            for (double i=0.0; i<5.0; i+=delta) {
+                current_state.pos()(2) = current_state.pos()(2) - delta;
+                man_positions.push_back(current_state);
+            }
+            for (double i=0.0; i<5.0; i+=delta) {
+                current_state.pos()(2) = current_state.pos()(2) + delta;
+                man_positions.push_back(current_state);
+            }
+        }
+
+//        // move in a 4mx2m rectangle parallel to the ground 3 times
+//        for (int repeat = 0; repeat<1; repeat++){
+//            // move 1 meter in the +y direction
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(1) = current_state.pos()(1) + delta;
+//                man_positions.push_back(current_state);
+//            }
+//            // move 1 meter in the +x direction
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(0) = current_state.pos()(0) + delta;
+//                man_positions.push_back(current_state);
+//            }
+//            // move 2 meters in the -y direction
+//            for (double i=0.0; i<10.0; i+=delta) {
+//                current_state.pos()(1) = current_state.pos()(1) - delta;
+//                man_positions.push_back(current_state);
+//            }
+//            // move 1 meters in the -x direction
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(0) = current_state.pos()(0) - delta;
+//                man_positions.push_back(current_state);
+//            }
+//            // move 1 meter in the +y direction
+//            for (double i=0.0; i<5.0; i+=delta) {
+//                current_state.pos()(1) = current_state.pos()(1) + delta;
+//                man_positions.push_back(current_state);
+//            }
+//        }
+
+        // place back at beginning for Straight Plugin
+        man_positions.push_back(init_state);
+
+        return man_positions;
+}
+
+void Square::init(std::map<std::string, std::string> &params) {
+    speed_ = scrimmage::get("speed", params, 0.0);
+    show_camera_images_ = scrimmage::get<bool>("show_camera_images", params, false);
+    save_camera_images_ = scrimmage::get<bool>("save_camera_images", params, false);
+    sq_side_length_m_ = scrimmage::get<double>("sq_side_length_m", params, 100);
+
+    // record the initial state:
+    init_man_goal_pos_ = state_->pos();
+    init_man_goal_quat_ = state_->quat();
+
+    // Project goal in front...
+//    Eigen::Vector3d rel_pos = Eigen::Vector3d::UnitX()*1e6;
+//    Eigen::Vector3d unit_vector = rel_pos.normalized();
+//    unit_vector = state_->quat().rotate(unit_vector);
+//    goal_ = state_->pos() + unit_vector * rel_pos.norm();
+//    goal_(2) = state_->pos()(2);
+
+    cout << "speed: " << speed_ << endl;
+
+    // initialize the corner locations of the square
+    // positve x direction
+    goal1_ = state_->pos();
+    goal1_(0) = goal1_(0) + sq_side_length_m_;
+    cout << "goal1: " << goal1_ << endl;
+    // positve y direction
+    goal2_ = goal1_;
+    goal2_(1) = goal2_(1) + sq_side_length_m_;
+    cout << "goal2: " << goal2_ << endl;
+    // negative x direction
+    goal3_ = goal2_;
+    goal3_(0) = goal3_(0) - sq_side_length_m_;
+    cout << "goal3: " << goal3_ << endl;
+    // negative y direction
+    goal4_ = goal3_;
+    goal4_(1) = goal4_(1) - sq_side_length_m_;
+    cout << "goal4: " << goal4_ << endl;
+
+    goal_ = goal1_;
+
+    // Set the desired_z to our initial position.
+    // desired_z_ = state_->pos()(2);
+    init_goal_ = state_->pos();
+    cout << "original init_goal_: " << init_goal_ << endl;
+
+    // Register the desired_z parameter with the parameter server
+    auto param_cb = [&](const double &desired_z) {
+        std::cout << "desired_z param changed at: " << time_->t()
+        << ", with value: " << desired_z << endl;
+    };
+    register_param<double>("desired_z", goal_(2), param_cb);
+
+    if (save_camera_images_) {
+        /////////////////////////////////////////////////////////
+        // Remove all img files from previous run
+        if (fs::exists("./imgs")) {
+            fs::recursive_directory_iterator it("./imgs");
+            fs::recursive_directory_iterator endit;
+            std::list<fs::path> paths_to_rm;
+            while (it != endit) {
+                fs::path path = it->path();
+                if (fs::is_regular_file(*it) && path.extension() == ".png") {
+                    paths_to_rm.push_back(path);
+                }
+                ++it;
+            }
+            for (fs::path p : paths_to_rm) {
+                fs::remove(p);
+            }
+        } else {
+            fs::create_directories("./imgs");
+        }
+        /////////////////////////////////////////////////////////
+    }
+
+    frame_number_ = 0;
+
+    // If using an initialization maneuver, then compile the position vector
+    use_init_maneuver_ = sc::get<bool>("use_init_maneuver", params, "false");
+    if (use_init_maneuver_) {
+        man_positions_ = get_init_maneuver_positions();
+        cout << "[Square] Start VO Initialization Maneuver." << endl;
+    }
+
+//    enable_boundary_control_ = get<bool>("enable_boundary_control", params, false);
+//
+//    auto bd_cb = [&](auto &msg) {boundary_ = sci::Boundary::make_boundary(msg->data);};
+//    subscribe<sp::Shape>("GlobalNetwork", "Boundary", bd_cb);
+
+    auto state_cb = [&](auto &msg) {
+        noisy_state_set_ = true;
+        noisy_state_ = msg->data;
+    };
+    subscribe<StateWithCovariance>("LocalNetwork", "StateWithCovariance", state_cb);
+
+    auto cnt_cb = [&](scrimmage::MessagePtr<ContactMap> &msg) {
+        noisy_contacts_ = msg->data; // Save map of noisy contacts
+    };
+    subscribe<ContactMap>("LocalNetwork", "ContactsWithCovariances", cnt_cb);
+
+#if (ENABLE_OPENCV == 1 && ENABLE_AIRSIM == 1)
+    auto airsim_cb = [&](auto &msg) {
+        for (sc::sensor::AirSimImageType a : msg->data) {
+            if (show_camera_images_) {
+                // Get Camera Name
+                std::string window_name = a.vehicle_name + "_" + a.camera_config.cam_name + "_" + a.camera_config.img_type_name;
+                // for depth images CV imshow expects grayscale image values to be between 0 and 1.
+                if (a.camera_config.img_type_name == "DepthPerspective" || a.camera_config.img_type_name == "DepthPlanner") {
+                    // Worked before building with ROS
+                    cv::Mat tempImage;
+                    a.img.convertTo(tempImage, CV_32FC1, 1.f/255);
+                    // cv::normalize(a.img, tempImage, 0, 1, cv::NORM_MINMAX);
+                    // cout << tempImage << endl;
+                    cv::imshow(window_name, tempImage);
+                } else {
+                    // other image types are int 0-255.
+                    if (a.img.channels() == 4) {
+                        cout << "image channels: " << a.img.channels() << endl;
+                        cout << "Warning: Old AirSim Linux Asset Environments have 4 channels. Color images will not display correctly." << endl;
+                        cout << "Warning: Use Asset Environment versions Linux-v1.3.1+." << endl;
+                        cv::Mat tempImage;
+                        cv::cvtColor(a.img , tempImage, CV_RGBA2RGB);
+                        cv::imshow(window_name, tempImage);
+                    } else {
+                        cv::imshow(window_name, a.img);
+                    }
+                }
+                cv::waitKey(1);
+            }
+        }
+    };
+    subscribe<std::vector<sensor::AirSimImageType>>("LocalNetwork", "AirSimImages", airsim_cb);
+#endif
+
+#if ENABLE_OPENCV == 1
+    auto blob_cb = [&](auto &msg) {
+        if (save_camera_images_) {
+            std::string img_name = "./imgs/camera_" +
+                std::to_string(frame_number_++) + ".png";
+            cv::imwrite(img_name, msg->data.frame);
+        }
+
+        if (show_camera_images_) {
+            cv::imshow("Camera Sensor", msg->data.frame);
+            cv::waitKey(1);
+        }
+    };
+    subscribe<sc::sensor::ContactBlobCameraType>("LocalNetwork", "ContactBlobCamera", blob_cb);
+#endif
+
+//    gen_ents_ = sc::get("generate_entities", params, gen_ents_);
+//    if (gen_ents_) {
+//        pub_gen_ents_ = advertise("GlobalNetwork", "GenerateEntity");
+//    }
+
+    desired_alt_idx_ = vars_.declare(VariableIO::Type::desired_altitude, VariableIO::Direction::Out);
+    desired_speed_idx_ = vars_.declare(VariableIO::Type::desired_speed, VariableIO::Direction::Out);
+    desired_heading_idx_ = vars_.declare(VariableIO::Type::desired_heading, VariableIO::Direction::Out);
+}
+
+bool Square::step_autonomy(double t, double dt) {
+
+    // Read data from sensors...
+    if (!noisy_state_set_) {
+        noisy_state_ = *state_;
+    }
+
+//    if (boundary_ != nullptr && enable_boundary_control_) {
+//        if (!boundary_->contains(noisy_state_.pos())) {
+//            // Project goal through center of boundary
+//            Eigen::Vector3d center = boundary_->center();
+//            center(2) = noisy_state_.pos()(2); // maintain altitude
+//            Eigen::Vector3d diff = center - noisy_state_.pos();
+//            goal_ = noisy_state_.pos() + diff.normalized() * 1e6;
+//        }
+//    }
+
+    Eigen::Vector3d diff;
+    Eigen::Vector3d v;
+    double altitude = goal_(2);
+    // double heading = init_man_goal_quat_.yaw();
+
+
+    if (man_positions_.size() == 0 && use_init_maneuver_) {
+        init_maneuver_finished_ = true;
+        goal_ = init_goal_;
+        cout << "init maneuver finished" << endl;
+    }
+
+    if (!init_maneuver_finished_ && use_init_maneuver_) {
+
+        // Pop a state off the front of man_positions_ vector and delete the element
+        float distance = sqrt(pow((init_man_goal_pos_(0) - noisy_state_.pos()(0)), 2) + pow((init_man_goal_pos_(1) - noisy_state_.pos()(1)), 2));
+        if (distance < 0.05) {
+            State next_state = man_positions_.front();
+            man_positions_.pop_front();
+            // cout << "remaining man_pos: " << man_positions_.size() << endl;
+            init_man_goal_pos_ = next_state.pos();
+            init_man_goal_quat_ = next_state.quat();
+        }
+
+        cout << "remaining man_pos: " << man_positions_.size() << endl;
+
+        cout << "next_state: " << init_man_goal_pos_ << endl;
+        // create desired goal and velocity
+        diff = init_man_goal_pos_ - noisy_state_.pos();
+        v = 5.0 * diff.normalized();
+        // heading = init_man_goal_quat_.yaw();
+        altitude = init_man_goal_pos_(2);
+
+    } else {
+
+        // if init maneuver was used, start the drones at the starting point
+        if(square_side_ == 0) {
+            if(use_init_maneuver_) {
+                float distance = sqrt(pow((goal_(0) - noisy_state_.pos()(0)), 2) + pow((goal_(1) - noisy_state_.pos()(1)), 2));
+                if (distance < 5) {
+                    square_side_ += 1;
+                    goal_ = goal1_;
+                }
+            }
+            else{
+                square_side_ += 1;
+            }
+        }
+
+        // check if we have completed this side
+        float distance = sqrt(pow((init_goal_(0) - state_->pos()(0)), 2) + pow((init_goal_(1) - state_->pos()(1)), 2));
+//        cout << "distance: " << distance << endl;
+//        cout << "sq_side_length_m_: " << sq_side_length_m_ << endl;
+//        cout << "square_side_: " << square_side_ << endl;
+//        cout << "position: " << state_->pos()<< endl;
+        if (distance >= sq_side_length_m_ && square_side_ > 0){
+            // update which side of the square we are on.
+            square_side_ += 1;
+            init_goal_ = goal_;
+
+            // rotate the goal
+            int current_side = square_side_ % 4;
+            switch(current_side) {
+                case 1:
+                  {
+                      // cout << '1' << endl; // prints "1"
+                      // Project goal in front...
+                      // Move in positive X direction
+                        goal_ = goal1_;
+                      break;
+                  }
+                case 2 :
+                  {
+                      // cout << '2' << endl;
+                      // Project goal in front...
+                      // Move in positive Y direction
+                      goal_ = goal2_;
+                      break;
+                  }
+                case 3:
+                  {
+                      // cout << '3' << endl;
+                      // Project goal in front...
+                      // Move in negative X direction
+                      goal_ = goal3_;
+                      break;
+                  }
+                case 0:
+                  {
+                      // cout << '4' << endl;
+                      // Project goal in front...
+                      // Move in negative Y direction
+                      goal_ = goal4_;
+                      break;
+                  }
+            }
+            cout << "goal: " << goal_ << endl;
+        }
+
+     // create desired goal and velocity
+    diff = goal_ - noisy_state_.pos();
+    v = speed_ * diff.normalized();
+    altitude = goal_(2);
+    // heading = Angles::angle_2pi(atan2(v(1), v(0)));
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Convert desired velocity to desired speed, heading, and pitch controls
+    ///////////////////////////////////////////////////////////////////////////
+    double heading = Angles::angle_2pi(atan2(v(1), v(0)));
+    vars_.output(desired_alt_idx_, altitude);
+    vars_.output(desired_speed_idx_, v.norm());
+    vars_.output(desired_heading_idx_, heading);
+
+    noisy_state_set_ = false;
+    return true;
+}
+} // namespace autonomy
+} // namespace scrimmage

--- a/src/plugins/autonomy/StraightVOInit/CMakeLists.txt
+++ b/src/plugins/autonomy/StraightVOInit/CMakeLists.txt
@@ -1,0 +1,42 @@
+#--------------------------------------------------------
+# Library Creation
+#--------------------------------------------------------
+SET (LIBRARY_NAME StraightVOInit_plugin)
+SET (LIB_MAJOR 0)
+SET (LIB_MINOR 0)
+SET (LIB_RELEASE 1)
+
+file(GLOB SRCS *.cpp)
+
+ADD_LIBRARY(${LIBRARY_NAME} SHARED
+  ${SRCS}
+  )
+
+TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
+  Boundary_plugin
+  scrimmage-core
+  )
+
+if (OpenCV_FOUND)
+  TARGET_LINK_LIBRARIES(${LIBRARY_NAME}
+    scrimmage-opencv
+    )
+endif()
+
+SET (_soversion ${LIB_MAJOR}.${LIB_MINOR}.${LIB_RELEASE})
+
+set_target_properties(${LIBRARY_NAME} PROPERTIES
+  SOVERSION ${LIB_MAJOR}
+  VERSION ${_soversion}
+  LIBRARY_OUTPUT_DIRECTORY ${PROJECT_PLUGIN_LIBS_DIR}
+  )
+
+install(TARGETS ${LIBRARY_NAME}
+  # IMPORTANT: Add the library to the "export-set"
+  EXPORT ${PROJECT_NAME}-targets
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib/${PROJECT_NAME}/plugin_libs
+)
+
+# Push up the PROJECT_PLUGINS variable
+set(PROJECT_PLUGINS ${PROJECT_PLUGINS} ${LIBRARY_NAME} PARENT_SCOPE)

--- a/src/plugins/autonomy/StraightVOInit/StraightVOInit.cpp
+++ b/src/plugins/autonomy/StraightVOInit/StraightVOInit.cpp
@@ -1,0 +1,362 @@
+/*!
+ * @file
+ *
+ * @section LICENSE
+ *
+ * Copyright (C) 2017 by the Georgia Tech Research Institute (GTRI)
+ *
+ * This file is part of SCRIMMAGE.
+ *
+ *   SCRIMMAGE is free software: you can redistribute it and/or modify it under
+ *   the terms of the GNU Lesser General Public License as published by the
+ *   Free Software Foundation, either version 3 of the License, or (at your
+ *   option) any later version.
+ *
+ *   SCRIMMAGE is distributed in the hope that it will be useful, but WITHOUT
+ *   ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ *   FITNESS FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public
+ *   License for more details.
+ *
+ *   You should have received a copy of the GNU Lesser General Public License
+ *   along with SCRIMMAGE.  If not, see <http://www.gnu.org/licenses/>.
+ *
+ * @author Kevin DeMarco <kevin.demarco@gtri.gatech.edu>
+ * @author Eric Squires <eric.squires@gtri.gatech.edu>
+ * @date 31 July 2017
+ * @version 0.1.0
+ * @brief Brief file description.
+ * @section DESCRIPTION
+ * A Long description goes here.
+ *
+ */
+
+#include <scrimmage/common/Utilities.h>
+#include <scrimmage/common/Shape.h>
+#include <scrimmage/common/Time.h>
+#include <scrimmage/entity/Entity.h>
+#include <scrimmage/math/State.h>
+#include <scrimmage/math/StateWithCovariance.h>
+#include <scrimmage/math/Angles.h>
+#include <scrimmage/parse/ParseUtils.h>
+#include <scrimmage/plugin_manager/RegisterPlugin.h>
+#include <scrimmage/plugins/interaction/Boundary/BoundaryBase.h>
+#include <scrimmage/plugins/interaction/Boundary/Boundary.h>
+#include <scrimmage/proto/State.pb.h>
+#include <scrimmage/msgs/Event.pb.h>
+#include <scrimmage/pubsub/Message.h>
+#include <scrimmage/pubsub/Subscriber.h>
+#include <scrimmage/pubsub/Publisher.h>
+#include <scrimmage/sensor/Sensor.h>
+
+#if ENABLE_OPENCV == 1
+#include <scrimmage/plugins/sensor/ContactBlobCamera/ContactBlobCameraType.h>
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#endif
+
+#if ENABLE_AIRSIM == 1
+#include <scrimmage/plugins/sensor/AirSimSensor/AirSimSensor.h>
+#endif
+
+#include <scrimmage/plugins/interaction/Boundary/Cuboid.h>
+
+namespace sc = scrimmage;
+namespace sp = scrimmage_proto;
+namespace sci = scrimmage::interaction;
+
+#include <scrimmage/plugins/autonomy/StraightVOInit/StraightVOInit.h>
+
+#define BOOST_NO_CXX11_SCOPED_ENUMS
+#include <boost/filesystem.hpp>
+#undef BOOST_NO_CXX11_SCOPED_ENUMS
+namespace fs = boost::filesystem;
+
+REGISTER_PLUGIN(scrimmage::Autonomy,
+                scrimmage::autonomy::StraightVOInit,
+                StraightVOInit_plugin)
+
+namespace scrimmage {
+namespace autonomy {
+
+std::deque<State> StraightVOInit::get_init_maneuver_positions() {
+
+        std::deque<State> man_positions;
+
+        // get the starting position
+        sc::StatePtr &state = parent_->state_truth();
+        State init_state(*state);
+        State current_state(*state);
+        // man_positions.push_back(current_state);
+
+        // Rise up to 5 meters above the starting position
+//        for (double i=0.0; i<5.0; i+=delta) {
+//            current_state.pos()(2) = current_state.pos()(2) + delta;
+//            man_positions.push_back(current_state);
+//        }
+        // cout << "starting_state: " <<  current_state.pos() << endl;
+        // add 5m in altitude
+        // current_state.pos()(2) = current_state.pos()(2) + 5.0;
+        man_positions.push_back(current_state);
+
+        // move left - right
+        current_state.pos()(1) = current_state.pos()(1) + 4.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(1) = current_state.pos()(1) - 8.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(1) = current_state.pos()(1) + 4.0;
+        man_positions.push_back(current_state);
+
+        // move up-down
+        current_state.pos()(2) = current_state.pos()(2) + 4.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(2) = current_state.pos()(2) - 8.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(2) = current_state.pos()(2) + 4.0;
+        man_positions.push_back(current_state);
+
+        // move in a rectangle - right, forward, left, backward, right
+        current_state.pos()(1) = current_state.pos()(1) + 4.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(0) = current_state.pos()(0) + 4.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(1) = current_state.pos()(1) - 8.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(0) = current_state.pos()(0) - 4.0;
+        man_positions.push_back(current_state);
+        current_state.pos()(1) = current_state.pos()(1) + 4.0;
+        man_positions.push_back(current_state);
+
+        // place back at beginning for Straight Plugin
+        man_positions.push_back(init_state);
+        man_positions.push_back(init_state);
+        man_positions.push_back(init_state);
+
+
+        return man_positions;
+}
+
+void StraightVOInit::init(std::map<std::string, std::string> &params) {
+    speed_ = scrimmage::get("speed", params, 0.0);
+    show_camera_images_ = scrimmage::get<bool>("show_camera_images", params, false);
+    save_camera_images_ = scrimmage::get<bool>("save_camera_images", params, false);
+
+    // Project goal in front...
+    Eigen::Vector3d rel_pos = Eigen::Vector3d::UnitX()*1e6;
+    Eigen::Vector3d unit_vector = rel_pos.normalized();
+    unit_vector = state_->quat().rotate(unit_vector);
+    goal_ = state_->pos() + unit_vector * rel_pos.norm();
+    goal_(2) = state_->pos()(2);
+    init_goal_ = goal_;
+
+    // Set the desired_z to our initial position.
+    // desired_z_ = state_->pos()(2);
+
+    // Register the desired_z parameter with the parameter server
+    auto param_cb = [&](const double &desired_z) {
+        std::cout << "desired_z param changed at: " << time_->t()
+        << ", with value: " << desired_z << endl;
+    };
+    register_param<double>("desired_z", goal_(2), param_cb);
+
+    if (save_camera_images_) {
+        /////////////////////////////////////////////////////////
+        // Remove all img files from previous run
+        if (fs::exists("./imgs")) {
+            fs::recursive_directory_iterator it("./imgs");
+            fs::recursive_directory_iterator endit;
+            std::list<fs::path> paths_to_rm;
+            while (it != endit) {
+                fs::path path = it->path();
+                if (fs::is_regular_file(*it) && path.extension() == ".png") {
+                    paths_to_rm.push_back(path);
+                }
+                ++it;
+            }
+            for (fs::path p : paths_to_rm) {
+                fs::remove(p);
+            }
+        } else {
+            fs::create_directories("./imgs");
+        }
+        /////////////////////////////////////////////////////////
+    }
+
+    frame_number_ = 0;
+
+    // If using an initialization maneuver, then compile the position vector
+    use_init_maneuver_ = sc::get<bool>("use_init_maneuver", params, "false");
+    // create an init maneuver publisher
+    init_maneuver_pub_ = advertise("LocalNetwork", "InitManeuver");
+    init_maneuver_finished_ = true;
+    if (use_init_maneuver_) {
+        man_positions_ = get_init_maneuver_positions();
+        init_maneuver_finished_ = false;
+        cout << "[StraightVOInit Autonomy] Start VO Initialization Maneuver." << endl;
+
+        State next_state = man_positions_.front();
+        man_positions_.pop_front();
+        init_man_goal_pos_ = next_state.pos();
+        init_man_goal_quat_ = next_state.quat();
+    }
+
+    enable_boundary_control_ = get<bool>("enable_boundary_control", params, false);
+
+    auto bd_cb = [&](auto &msg) {boundary_ = sci::Boundary::make_boundary(msg->data);};
+    subscribe<sp::Shape>("GlobalNetwork", "Boundary", bd_cb);
+
+    auto state_cb = [&](auto &msg) {
+        noisy_state_set_ = true;
+        noisy_state_ = msg->data;
+    };
+    subscribe<StateWithCovariance>("LocalNetwork", "StateWithCovariance", state_cb);
+
+    auto cnt_cb = [&](scrimmage::MessagePtr<ContactMap> &msg) {
+        noisy_contacts_ = msg->data; // Save map of noisy contacts
+    };
+    subscribe<ContactMap>("LocalNetwork", "ContactsWithCovariances", cnt_cb);
+
+#if (ENABLE_OPENCV == 1 && ENABLE_AIRSIM == 1)
+    auto airsim_cb = [&](auto &msg) {
+        for (sc::sensor::AirSimImageType a : msg->data) {
+            if (show_camera_images_) {
+                // Get Camera Name
+                std::string window_name = a.vehicle_name + "_" + a.camera_config.cam_name + "_" + a.camera_config.img_type_name;
+                // for depth images CV imshow expects grayscale image values to be between 0 and 1.
+                if (a.camera_config.img_type_name == "DepthPerspective" || a.camera_config.img_type_name == "DepthPlanner") {
+                    // Worked before building with ROS
+                    cv::Mat tempImage;
+                    a.img.convertTo(tempImage, CV_32FC1, 1.f/255);
+                    // cv::normalize(a.img, tempImage, 0, 1, cv::NORM_MINMAX);
+                    // cout << tempImage << endl;
+                    cv::imshow(window_name, tempImage);
+                } else {
+                    // other image types are int 0-255.
+                    if (a.img.channels() == 4) {
+                        cout << "image channels: " << a.img.channels() << endl;
+                        cout << "Warning: Old AirSim Linux Asset Environments have 4 channels. Color images will not display correctly." << endl;
+                        cout << "Warning: Use Asset Environment versions Linux-v1.3.1+." << endl;
+                        cv::Mat tempImage;
+                        cv::cvtColor(a.img , tempImage, CV_RGBA2RGB);
+                        cv::imshow(window_name, tempImage);
+                    } else {
+                        cv::imshow(window_name, a.img);
+                    }
+                }
+                cv::waitKey(1);
+            }
+        }
+    };
+    subscribe<std::vector<sensor::AirSimImageType>>("LocalNetwork", "AirSimImages", airsim_cb);
+#endif
+
+#if ENABLE_OPENCV == 1
+    auto blob_cb = [&](auto &msg) {
+        if (save_camera_images_) {
+            std::string img_name = "./imgs/camera_" +
+                std::to_string(frame_number_++) + ".png";
+            cv::imwrite(img_name, msg->data.frame);
+        }
+
+        if (show_camera_images_) {
+            cv::imshow("Camera Sensor", msg->data.frame);
+            cv::waitKey(1);
+        }
+    };
+    subscribe<sc::sensor::ContactBlobCameraType>("LocalNetwork", "ContactBlobCamera", blob_cb);
+#endif
+
+    desired_alt_idx_ = vars_.declare(VariableIO::Type::desired_altitude, VariableIO::Direction::Out);
+    desired_speed_idx_ = vars_.declare(VariableIO::Type::desired_speed, VariableIO::Direction::Out);
+    desired_heading_idx_ = vars_.declare(VariableIO::Type::desired_heading, VariableIO::Direction::Out);
+}
+
+bool StraightVOInit::step_autonomy(double t, double dt) {
+
+    // Read data from sensors...
+    if (!noisy_state_set_) {
+        noisy_state_ = *state_;
+    }
+
+    Eigen::Vector3d current_goal;
+    Eigen::Vector3d diff;
+    Eigen::Vector3d v;
+    double altitude = goal_(2);
+
+    if (man_positions_.size() == 0 && use_init_maneuver_ && init_maneuver_finished_ == false) {
+        init_maneuver_finished_ = true;
+        goal_ = init_goal_;
+        prev_diff_ = {0,0,0};
+        cout << "init maneuver finished at time: " << t << endl;
+    }
+
+    // Publish the Init Maneuver Status to send to AirSimSensor
+    // This is necessary to prevent the quadcopter from rotating during the init maneuver
+    // for Visual Odometry init maneuver we need the camera to stay facing forward
+    auto msg = std::make_shared<sc::Message<InitManeuverType>>();
+    msg->data.active = !init_maneuver_finished_;
+    init_maneuver_pub_->publish(msg);
+
+    if (!init_maneuver_finished_ && use_init_maneuver_) {
+        // Pop a state off the front of man_positions_ vector and delete the element
+        float distance = sqrt(pow((init_man_goal_pos_(0) - noisy_state_.pos()(0)), 2) + pow((init_man_goal_pos_(1) - noisy_state_.pos()(1)), 2) + pow((init_man_goal_pos_(2) - noisy_state_.pos()(2)), 2));
+        if (distance < 0.5) {
+            State next_state = man_positions_.front();
+            man_positions_.pop_front();
+            init_man_goal_pos_ = next_state.pos();
+            v = {0, 0, 0};
+            altitude = init_man_goal_pos_(2);
+            prev_diff_ = {0, 0, 0};
+        }
+
+        // PD Controller
+        // create desired goal and velocity
+        // 1.0, 1.0 - bad overshoot
+        // 0.5, 50 is good
+        // 0.4/50 and 0.5/60 and 0.5/55 gives dead stop at corners
+        double kp = 0.6;
+        double kd = 60.0;
+        double init_man_speed = 5.0;
+        diff = init_man_goal_pos_ - noisy_state_.pos();
+        v = init_man_speed * (kp*diff + kd*(diff - prev_diff_));
+        // calculate the new desired altitude
+        altitude = noisy_state_.pos()(2) + v(2)*dt;
+        // do not count z in the velocity normalization
+        v(2) = 0.0;
+        // heading should stay facing the original heading
+        noisy_state_.set_quat(init_man_goal_quat_);
+        prev_diff_ = diff;
+
+    } else {
+
+	// If not performing init maneuver move the quadcopter in a straight line
+	
+	// If quadcopter reaches boundary lines
+        if (boundary_ != nullptr && enable_boundary_control_) {
+            if (!boundary_->contains(noisy_state_.pos())) {
+                // Project goal through center of boundary
+                Eigen::Vector3d center = boundary_->center();
+                center(2) = noisy_state_.pos()(2); // maintain altitude
+                Eigen::Vector3d diff = center - noisy_state_.pos();
+                goal_ = noisy_state_.pos() + diff.normalized() * 1e6;
+            }
+        }
+
+        Eigen::Vector3d diff = goal_ - noisy_state_.pos();
+        v = speed_ * diff.normalized();
+        altitude = goal_(2);
+    }
+
+    ///////////////////////////////////////////////////////////////////////////
+    // Convert desired velocity to desired speed, heading, and pitch controls
+    ///////////////////////////////////////////////////////////////////////////
+    double heading = Angles::angle_2pi(atan2(v(1), v(0)));
+    vars_.output(desired_alt_idx_, altitude);
+    vars_.output(desired_speed_idx_, v.norm());
+    vars_.output(desired_heading_idx_, heading);
+
+    noisy_state_set_ = false;
+    return true;
+}
+} // namespace autonomy
+} // namespace scrimmage


### PR DESCRIPTION
Added Square Scrimmage plugin which flies entities in square flight pattern, can be used without the AirSimSensor/ ROSAirSim Plugins. Also added example mission file. This Plugin includes the visual odometry initialization maneuver.

Added StraightVOInit Plugin which is the classic Scrimmage Straight plugin with the visual odometry initialization maneuver added. Also added example mission file for this as well. Can use the boundary box setting to keep quadcopter inside the limits of the MS AirSim prefabricated photo-realistic environments.

Added the creation of data logging CSVs to Altimeter, Compass, and IMU sensor plugins that get saved in the ~/.scrimmage/logs directory