### PR TITLE
Added <output_dir_trailer> tag to the XML parsing

### DIFF
--- a/docs/source/overview/xml-tags.rst
+++ b/docs/source/overview/xml-tags.rst
@@ -108,10 +108,10 @@ and match between the two paradigms for a single entity.
   log information from the simulation. This includes entity trajectory data,
   event data, and the random seed that was used during the simulation.
 
-- ``output_dir_trailer`` : If defined, this will append a trailing string to 
-  the simulation's output directory's name. Note: it will be truncated to 100 
-  characters, and all occurrences of '/' will be replaced with an underscore 
-  '_'.
+- ``output_dir_trailer`` : If defined, this string will be appended as a
+  trailing string to the simulation's output directory's name. Note: it will
+  be truncated to 100 characters, and all occurrences of '/' will be replaced
+  with an underscore '_'.
 
 - ``create_latest_dir`` : If ``true``, a symbolically linked directory named
   ``latest`` will be created that links to the most recent ``log_dir``. This

--- a/docs/source/overview/xml-tags.rst
+++ b/docs/source/overview/xml-tags.rst
@@ -108,6 +108,11 @@ and match between the two paradigms for a single entity.
   log information from the simulation. This includes entity trajectory data,
   event data, and the random seed that was used during the simulation.
 
+- ``output_dir_trailer`` : If defined, this will append a trailing string to 
+  the simulation's output directory's name. Note: it will be truncated to 100 
+  characters, and all occurrences of '/' will be replaced with an underscore 
+  '_'.
+
 - ``create_latest_dir`` : If ``true``, a symbolically linked directory named
   ``latest`` will be created that links to the most recent ``log_dir``. This
   tag is ``true`` by default. When executing parallel runs, the user should set

--- a/include/scrimmage/parse/MissionParse.h
+++ b/include/scrimmage/parse/MissionParse.h
@@ -195,6 +195,7 @@ class MissionParse {
 
     std::string root_log_dir_;
     std::string log_dir_;
+    std::string output_dir_trailer_;
 
     double longitude_origin_ = 29.0;
     double latitude_origin_ = -95.0;

--- a/src/parse/MissionParse.cpp
+++ b/src/parse/MissionParse.cpp
@@ -309,6 +309,14 @@ bool MissionParse::parse(const std::string &filename) {
         root_log_dir_ = expand_user(params_["log_dir"]);
     }
 
+    // Is output_dir_trailer defined?
+    if (params_.count("output_dir_trailer") > 0) {
+        output_dir_trailer_ = "_" + params_["output_dir_trailer"].substr(0, 100);
+        std::replace(output_dir_trailer_.begin(), output_dir_trailer_.end(), '/', '_');
+    } else {
+        output_dir_trailer_ = "";
+    }
+
     // Create a directory to hold the log data
     // Use the current time for the directory's name
     time_t rawtime;
@@ -327,6 +335,7 @@ bool MissionParse::parse(const std::string &filename) {
     if (task_number_ != -1) {
         log_dir_ += "_task_" + std::to_string(task_number_);
     }
+    log_dir_ += output_dir_trailer_;
 
     int ent_desc_id = 0;
     int team_id_err = 0; // only used when team_id is not set "warn condition"


### PR DESCRIPTION
Allows the user to optionally specify a top-level tag `<output_dir_trailer>`, which will append a trailing string as defined by the user to the end of the simulation's output directory's name.

Note: truncates the string to 100 characters. Replaces all occurrences of '/' with '_'.

I tested with the following tag added to Straight.xml:
```
   <output_dir_trailer> [73%] Linking CXX shared library ../../../../plugin_libs/libSingleIntegratorControllerWaypointJustAddingSomeExtraCharactersHereToCauseTruncation_plugin.so</output_dir_trailer>
```

Yielding this directory:
```
$ ll
total 20
drwxrwxr-x 4 scrimmage scrimmage 4096 Feb 18 12:10  ./
drwxr-xr-x 4 scrimmage scrimmage 4096 Feb 18 11:33  ../
drwxrwxr-x 2 scrimmage scrimmage 4096 Feb 18 12:10 '2022-02-18_12-10-53_ [73%] Linking CXX shared library .._.._.._.._plugin_libs_libSingleIntegratorControllerWaypointJustA'/
lrwxrwxrwx 1 scrimmage scrimmage  152 Feb 18 12:10  latest -> '/home/scrimmage/.scrimmage/logs/2022-02-18_12-10-53_ [73%] Linking CXX shared library .._.._.._.._plugin_libs_libSingleIntegratorControllerWaypointJustA'/
$
```

Documentation/rst file `xml-tags.rst` also updated.

Closes: https://github.com/gtri/scrimmage/issues/542