### PR TITLE
Removed pkg-resources from requirements.txt and replaced it with setuptools

### DIFF
--- a/python/requirements-3.6.txt
+++ b/python/requirements-3.6.txt
@@ -22,7 +22,7 @@ more-itertools==8.3.0
 numpy==1.19.0rc1
 packaging==20.3
 pandas==1.0.3
-pkg-resources==0.0.0
+setuptools==42.0.0
 pluggy==0.13.1
 protobuf==3.3.0
 py==1.8.1

--- a/python/requirements-3.8.txt
+++ b/python/requirements-3.8.txt
@@ -21,7 +21,7 @@ more-itertools==8.3.0
 numpy==1.19.0rc1
 packaging==20.3
 pandas==1.0.3
-pkg-resources==0.0.0
+setuptools==42.0.0
 pluggy==0.13.1
 py==1.8.1
 pyglet==1.5.0


### PR DESCRIPTION
Replaced the packages in both `requirements-3.6.txt` and `requirements-3.8.txt`.

Installation of requirements worked fine for me in both Centos 7.9 with python 3.6.8 and Ubuntu 18.04 with anaconda3, using python 3.8.5.

See the issue for more details: https://github.com/gtri/scrimmage/issues/532

To test, follow the Python Bindings section in the main README.md
https://github.com/gtri/scrimmage#python-bindings

If you run it with the old requirements-3.6.txt, you should see an error. The error will no longer be there if you use the updated requirements-3.6.txt files from this PR.
