### PR TITLE
Bugfix/timeslipping

### DIFF
--- a/include/scrimmage/common/Timer.h
+++ b/include/scrimmage/common/Timer.h
@@ -45,6 +45,8 @@ class Timer {
 
     void start_loop_timer();
 
+    void pause_loop_timer();
+
     boost::posix_time::time_duration loop_wait();
 
     void set_iterate_rate(double iterate_rate);

--- a/include/scrimmage/common/Timer.h
+++ b/include/scrimmage/common/Timer.h
@@ -66,13 +66,15 @@ class Timer {
     boost::posix_time::ptime start_time_;
 
     boost::posix_time::ptime actual_time_;
-    boost::posix_time::time_duration actual_elapsed_time_;
 
     boost::posix_time::ptime sim_time_;
     boost::posix_time::time_duration sim_elapsed_time_;
 
     boost::posix_time::ptime loop_timer_;
+    bool loop_timer_running_;
+    boost::posix_time::ptime loop_end_time_;
     boost::posix_time::time_duration iterate_period_;
+    boost::posix_time::time_duration sim_time_period_;
     double iterate_rate_;
 };
 } // namespace scrimmage

--- a/include/scrimmage/simcontrol/SimControl.h
+++ b/include/scrimmage/simcontrol/SimControl.h
@@ -456,6 +456,7 @@ class SimControl {
     void setup_timer(double rate, double time_warp);
     void start_overall_timer();
     void start_loop_timer();
+    void pause_loop_timer();
     void loop_wait();
     void inc_warp();
     void dec_warp();

--- a/share/scrimmage-playback/main.cpp
+++ b/share/scrimmage-playback/main.cpp
@@ -164,6 +164,10 @@ void playback_loop(std::shared_ptr<sc::Log> log,
             if (single_step) {
                 break;
             }
+            if (paused) {
+                timer.pause_loop_timer();
+                std::this_thread::sleep_for(std::chrono::milliseconds(1));
+            }
         } while (paused && !exit_loop);
         if (exit_loop) break;
     }

--- a/src/common/Timer.cpp
+++ b/src/common/Timer.cpp
@@ -64,6 +64,10 @@ void Timer::start_loop_timer() {
     sim_time_ += sim_time_period_;
 }
 
+void Timer::pause_loop_timer() {
+    loop_timer_running_ = false;
+}
+
 boost::posix_time::time_duration Timer::loop_wait() {
     boost::posix_time::ptime time = boost::posix_time::microsec_clock::local_time();
     if (time > loop_end_time_) {

--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -1374,6 +1374,12 @@ void SimControl::start_loop_timer() {
     timer_mutex_.unlock();
 }
 
+void SimControl::pause_loop_timer() {
+    timer_mutex_.lock();
+    timer_.pause_loop_timer();
+    timer_mutex_.unlock();
+}
+
 void SimControl::loop_wait() {
     timer_mutex_.lock();
     timer_.loop_wait();


### PR DESCRIPTION
Simulation previously calculated how long to sleep after completing step activities based on when current step started.  Slight oversleep errors and time in between end of step and next step accumulate causing the simulation to run slower than programmed.  This update creates a reference time to calculate sleep duration after completing step activities. 