### PR TITLE
548 Frames.bin missing last few frames occasionally

### DIFF
--- a/include/scrimmage/log/Log.h
+++ b/include/scrimmage/log/Log.h
@@ -182,7 +182,7 @@ class Log {
                            MessageLitePtr message,
                            bool& clean_eof);
 
-    bool close_stream(ZeroCopyOutputStreamPtr stream);
+    bool close_fileoutputstream(ZeroCopyOutputStreamPtr stream);
 };
 } // namespace scrimmage
 #endif // INCLUDE_SCRIMMAGE_LOG_LOG_H_

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -369,7 +369,8 @@ bool Log::readDelimitedFrom(const std::string &filename,
     return true;
 }
 
-bool Log::close_stream(ZeroCopyOutputStreamPtr stream) {
+bool Log::close_fileoutputstream(ZeroCopyOutputStreamPtr stream) {
+    // Close() flushes the stream as well
     bool status = dynamic_cast<google::protobuf::io::FileOutputStream&>(*stream).Close();
     return status;
 }
@@ -381,10 +382,10 @@ bool Log::close_log() {
 
     google::protobuf::ShutdownProtobufLibrary();
 
-    close_stream(frames_output_);
-    close_stream(shapes_output_);
-    close_stream(utm_terrain_output_);
-    close_stream(contact_visual_output_);
+    close_fileoutputstream(frames_output_);
+    close_fileoutputstream(shapes_output_);
+    close_fileoutputstream(utm_terrain_output_);
+    close_fileoutputstream(contact_visual_output_);
 
     close(frames_fd_);
     close(shapes_fd_);


### PR DESCRIPTION
Closes https://github.com/gtri/scrimmage/issues/548

Please see the ticket for an in-depth description of the problem this addresses.

The `.reset()` method used on the file streams is part of `shared_ptr`, and what it does is call the destructor for the object, then create a new empty object for that pointer.

This was replaced with an explicit call to `google::protobuf::io::FileOutputStream.Close()` for the files that are created as `google::protobuf::io::FileOutputStream`. This `Close()` call explicitly flushes and closes out the stream properly. The other change to close out this ticket was to add explicit `close()` calls for the file descriptors used by the streams.