### PR TITLE
Modified CSV utility to make writing doubles more configurable

### DIFF
--- a/include/scrimmage/common/CSV.h
+++ b/include/scrimmage/common/CSV.h
@@ -81,6 +81,11 @@ class CSV {
 
     bool equals(const CSV& other);
 
+    // double parameters
+    void set_double_precision(int precision) { double_precision_ = precision; }
+    void set_double_fixed(bool is_fixed) { double_is_fixed_ = is_fixed; }
+    void set_double_scientific(bool is_scientific) { double_is_scientific_ = is_scientific; }
+
  protected:
     std::list<std::string> get_csv_line_elements(const std::string &str);
 
@@ -102,6 +107,10 @@ class CSV {
     std::string no_value_str_ = "NaN";
 
  private:
+    int double_precision_ = 13;
+    bool double_is_fixed_ = true;
+    bool double_is_scientific_ = false;
+
     std::string headers_to_string() const;
     std::string rows_to_string() const;
     std::string row_to_string(const int& i) const;

--- a/src/common/CSV.cpp
+++ b/src/common/CSV.cpp
@@ -33,9 +33,11 @@
 #include <scrimmage/common/CSV.h>
 #include <scrimmage/parse/ParseUtils.h>
 
+#include <iomanip>
 #include <iostream>
 #include <vector>
 #include <fstream>
+#include <sstream>
 
 #include <boost/tokenizer.hpp>
 #include <boost/algorithm/string.hpp>
@@ -158,12 +160,19 @@ std::string CSV::row_to_string(const int& row) const {
     std::string result = "";
 
     // Initialize a vector with no value string. Iterate over
-    // column_headers, use column index to fill in columne for values.
+    // column_headers, use column index to fill in column for values.
     std::vector<std::string> values(column_headers_.size(), no_value_str_);
     auto it_row = table_.find(row);
     for (auto &kv : it_row->second) {
         if (static_cast<int64_t>(kv.second) == kv.second) {
             values[kv.first] = std::to_string(static_cast<int64_t>(kv.second));
+        } else if (static_cast<double>(kv.second) == kv.second) {
+            // default precision values for double are not enough in many cases
+            std::ostringstream conv;
+            if (double_is_fixed_) { conv << std::fixed; }
+            if (double_is_scientific_) { conv << std::scientific; }
+            conv << std::setprecision(double_precision_) << kv.second;
+            values[kv.first] = conv.str();
         } else {
             values[kv.first] = std::to_string(kv.second);
         }


### PR DESCRIPTION
Closes: https://github.com/gtri/scrimmage/issues/553

CSV utility class writes doubles with some default qualities that aren't granular enough for things like lat/lon, etc.

Made some modifications to the CSV class:
- now allow the user to set precision, fixed, or scientific for writing double values out to csv files
- defaults these items to what it looked like before but with more decimal precision (see below)

Note: this should write double values similar to previously, but now with more precision than before.
- doubles in scientific notation (`double d = 3.14e-9;`) never worked (tested)
- this now provides a way to write out doubles to csv using scientific notation
- limitation: these double formatting settings will apply to any doubles you are writing to csv with the given instance (this limitation has not changed)

```
scrimmage::CSV csv_;
...
csv_.double_is_scientific(true); // false by default
csv_.double_is_fixed(false);     // true by default
csv_.double_precision(10);       // 13 by default
```