### PR TITLE
python scrimmage/proto_utils add stream input capability

### DIFF
--- a/python/scrimmage/proto_utils.py
+++ b/python/scrimmage/proto_utils.py
@@ -33,7 +33,14 @@ from scrimmage.proto import Frame_pb2
 import google.protobuf.internal.decoder
 
 
+
+
 def read_frames(frames_file, to_dataframe=False):
+    frames_stream = open(frames_file, 'rb')
+    return read_frames_stream(frames_stream, to_dataframe)
+
+def read_frames_stream(frames_stream, to_dataframe=False):
+
     """Return a list of frames from a protobuf binary file.
 
     The protobuf frames file is a series of frames (see here:
@@ -50,8 +57,9 @@ def read_frames(frames_file, to_dataframe=False):
     The first link contains the code used below with the exception that decoder
     is _DecodeVarint32, found at the 2nd link
     """
-    with open(frames_file, 'rb') as f:
-        data = f.read()
+#    with open(frames_file, 'rb') as f:
+
+    data = frames_stream.read()
 
     frames = []
     next_pos, pos = 0, 0

--- a/python/scrimmage/proto_utils.py
+++ b/python/scrimmage/proto_utils.py
@@ -57,8 +57,6 @@ def read_frames_stream(frames_stream, to_dataframe=False):
     The first link contains the code used below with the exception that decoder
     is _DecodeVarint32, found at the 2nd link
     """
-#    with open(frames_file, 'rb') as f:
-
     data = frames_stream.read()
 
     frames = []


### PR DESCRIPTION
Closes: https://github.com/gtri/scrimmage/issues/560

In the scrimmage python package, `python/scrimmage/proto_utils.py`, added an explicit second function called `read_frames_stream()` to take a stream as input instead of a filename. The original `read_frames()` method is still there, and still takes in a filename, but it now calls/returns `read_frames_stream()`. `read_frames_stream()` now contains the full function body that `read_frames()` used to have. 

I have basically overloaded this, but with a different function name so that anyone using this package can be pretty sure they're using the one they intended to use.

**This change should not break anything that was already using this utility package.**

Motivation: I have a post processing utility that is complex and it passes around file streams instead of file names, and it would be easier and safer to add a second function to the scrimmage package to process streams than it would be to refactor the post processing utility to use filenames instead. The changes to this package simply allow either option for the user.

