### PR TITLE
Pause fix

### DIFF
--- a/include/scrimmage/common/Timer.h
+++ b/include/scrimmage/common/Timer.h
@@ -68,6 +68,7 @@ class Timer {
     boost::posix_time::ptime start_time_;
 
     boost::posix_time::ptime actual_time_;
+    boost::posix_time::time_duration actual_elapsed_time_; // Nat - removed
 
     boost::posix_time::ptime sim_time_;
     boost::posix_time::time_duration sim_elapsed_time_;

--- a/include/scrimmage/simcontrol/SimControl.h
+++ b/include/scrimmage/simcontrol/SimControl.h
@@ -456,7 +456,7 @@ class SimControl {
     void setup_timer(double rate, double time_warp);
     void start_overall_timer();
     void start_loop_timer();
-    void pause_loop_timer();
+    void pause_loop_timer(); // Nat - added
     void loop_wait();
     void inc_warp();
     void dec_warp();

--- a/share/scrimmage-playback/main.cpp
+++ b/share/scrimmage-playback/main.cpp
@@ -145,7 +145,8 @@ void playback_loop(std::shared_ptr<sc::Log> log,
                         timer.inc_warp();
                     } else if (it->dec_warp()) {
                         timer.dec_warp();
-                    } else if (it->toggle_pause()) {
+                    } else if (it->toggle_pause()) { // Nat - cannot seem to toggle once 'b' is initially pressed
+                        std::cout << "Pause toggled" << std::endl;
                         paused = !paused;
                     } else if (it->single_step()) {
                         single_step = true;
@@ -161,13 +162,18 @@ void playback_loop(std::shared_ptr<sc::Log> log,
             info.set_actual_warp(timer.time_warp());
             out_interface->send_sim_info(info);
 
+            std::cout << "In the playback loop" << std::endl;
+
             if (single_step) {
                 break;
             }
+            // Nat - Added
             if (paused) {
+                std::cout << "In if paused, calling the time pause loop timer" << std::endl; // never entered
                 timer.pause_loop_timer();
                 std::this_thread::sleep_for(std::chrono::milliseconds(1));
             }
+            //end of added
         } while (paused && !exit_loop);
         if (exit_loop) break;
     }
@@ -203,6 +209,7 @@ int main(int argc, char *argv[]) {
 
     cout << "Frames parsed: " << log->frames().size() << endl;
 
+    std::cout << "Play back thread is being created" << std::endl;
     std::thread playback(playback_loop, log, from_gui_interface,
                          to_gui_interface);
     playback.detach(); // todo

--- a/src/common/Timer.cpp
+++ b/src/common/Timer.cpp
@@ -41,9 +41,13 @@ namespace scrimmage {
 void Timer::start_overall_timer() {
     start_time_ = boost::posix_time::microsec_clock::local_time();
     actual_time_ = start_time_;
+    //actual_elapsed_time_ = start_time_ - start_time_; // 0 // Nat - removed
     sim_time_ = start_time_;
+    //sim_elapsed_time_ = start_time_ - start_time_; // 0 // Nat - removed
+    // Nat - added
     loop_end_time_ = loop_timer_ + iterate_period_;
     loop_timer_running_ = false;
+    // end of added
 }
 
 boost::posix_time::time_duration Timer::elapsed_time() {
@@ -52,31 +56,59 @@ boost::posix_time::time_duration Timer::elapsed_time() {
 
 void Timer::start_loop_timer() {
     loop_timer_ = boost::posix_time::microsec_clock::local_time();
+
+    //boost::posix_time::time_duration time_diff = loop_timer_ - actual_time_; // Nat - removed
+
+    // Nat - added
     if (!loop_timer_running_) {
         // set loop to end on current time
         loop_end_time_ = loop_timer_;
         loop_timer_running_ = true;
     }
     loop_end_time_ += iterate_period_;
+    // end of added
 
     actual_time_ = loop_timer_;
 
-    sim_time_ += sim_time_period_;
+    // Nat - removed
+    // actual_elapsed_time_ += time_diff;
+
+    // boost::posix_time::time_duration sim_time_diff = time_diff * time_warp_;
+    // sim_time_ += sim_time_diff;
+    // sim_elapsed_time_ += sim_time_diff;
+    // end of removed
+
+    sim_time_ += sim_time_period_; // Nat - added
 }
 
+// Nat - added
 void Timer::pause_loop_timer() {
     loop_timer_running_ = false;
 }
+// end of added
 
 boost::posix_time::time_duration Timer::loop_wait() {
     boost::posix_time::ptime time = boost::posix_time::microsec_clock::local_time();
+
+    // Nat - removed
+    // boost::posix_time::time_duration time_diff = time - loop_timer_;
+
+    // boost::posix_time::time_duration remainder = iterate_period_ - time_diff;
+    // if (time_diff < iterate_period_) {
+    //     boost::this_thread::sleep(remainder);
+    // }
+    // end of removed
+
+    // Nat - added
     if (time > loop_end_time_) {
+        std::cout << "In the loop end time is less than time" << std::endl; // This is essentially always entered when paused
         // already took too long, go to next period now.
         return boost::posix_time::time_duration(0, 0, 0, 0);
     }
 
     boost::posix_time::time_duration remainder = loop_end_time_ - time;
     boost::this_thread::sleep(remainder);
+    // end of added
 
     return remainder;
 }
@@ -96,8 +128,11 @@ void Timer::update_time_config() {
     } else {
         iterate_period_ = boost::posix_time::time_duration(0, 0, 0, 0);
     }
+
+    // Nat - added
     sim_time_period_ = iterate_period_ * time_warp_;
     loop_timer_running_ = false;
+    // end of added
 }
 
 uint64_t Timer::getnanotime() {

--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -1374,11 +1374,14 @@ void SimControl::start_loop_timer() {
     timer_mutex_.unlock();
 }
 
+// Nat - added
 void SimControl::pause_loop_timer() {
+    cout << "In pause loop timer for sim control" << endl; // Never entered
     timer_mutex_.lock();
     timer_.pause_loop_timer();
     timer_mutex_.unlock();
 }
+// end of added
 
 void SimControl::loop_wait() {
     timer_mutex_.lock();


### PR DESCRIPTION
Fixing the pause bug found from the following commit:

https://github.com/gtri/scrimmage/commit/c0a30363c91ff5113d89b25a950bf328ced0e3f6

"I'm getting an issue where, when I press b, the sim continues but the visuals stop. I've seen the problem on every commit after this one. I'm not quite sure what's happening, but I can definitely trace it back to this commit as the commit before this does not have the issue.

Issue: Sim continues running after pressing "b" to pause
How to recreate: checkout this commit or any commit after it, run a scrimmage mission with GUI enabled and pause the simulation for at least a few seconds. On unpausing, the simulation will jump to the time it would have been at without the pause almost instantly."

***Not ready for merge***