### PR TITLE
Scrimmage Fullscreen Fix

### DIFF
--- a/src/viewer/Viewer.cpp
+++ b/src/viewer/Viewer.cpp
@@ -87,6 +87,10 @@ bool Viewer::init(const std::shared_ptr<MissionParse>& mp,
     // Render and interact
     renderWindow_->SetWindowName("SCRIMMAGE");
     if (mp->full_screen()) {
+        // Don't use "FullScreenOn" or SetFullScreen(true).
+        // This uses the entire screen, prevents displaying the window name
+        // and makes it difficult to resize the window later.
+        renderWindow_->Render();
         renderWindow_->SetSize(renderWindow_->GetScreenSize());
     } else {
         renderWindow_->SetFullScreen(false);

--- a/src/viewer/Viewer.cpp
+++ b/src/viewer/Viewer.cpp
@@ -87,8 +87,7 @@ bool Viewer::init(const std::shared_ptr<MissionParse>& mp,
     // Render and interact
     renderWindow_->SetWindowName("SCRIMMAGE");
     if (mp->full_screen()) {
-        renderWindow_->SetFullScreen(true);
-        renderWindow_->FullScreenOn();
+        renderWindow_->SetSize(renderWindow_->GetScreenSize());
     } else {
         renderWindow_->SetFullScreen(false);
         renderWindow_->SetSize(mp->window_width(), mp->window_height());


### PR DESCRIPTION
	* Fixed bug causing vtkRenderWindows to not open when fullscreen is enabled, leaving the simulation in pause mode forever. Issue seemed to be related to the vtkRenderWindow member function SetFullScreen and FullScreenOn.