### PR TITLE
in FixedWing6DOF, fix bug to zero moments during launch

### DIFF
--- a/src/plugins/motion/FixedWing6DOF/FixedWing6DOF.cpp
+++ b/src/plugins/motion/FixedWing6DOF/FixedWing6DOF.cpp
@@ -535,7 +535,7 @@ void FixedWing6DOF::model(const vector_t &x , vector_t &dxdt , double t) {
         Moments_torque + Moments_gyro;
 
     if (POSTLAUNCH != launch_state_) {
-        Moments_total == Eigen::Vector3d::Zero();
+        Moments_total = Eigen::Vector3d::Zero();
     }
 
     // Calculate rotational velocites


### PR DESCRIPTION
Fixes a bug where a comparison operator was used instead of an assignment operator. Allows the moments to be zeroed during the acceleration portion of a vehicle launch.