### PR TITLE
Scrimmage 22.04 patches

### DIFF
--- a/include/scrimmage/entity/External.h
+++ b/include/scrimmage/entity/External.h
@@ -60,7 +60,7 @@
 #include <iostream>
 
 #include <boost/type_index.hpp>
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/function.hpp>
 
 namespace scrimmage {

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -309,7 +309,12 @@ bool Log::writeDelimitedTo(const google::protobuf::MessageLite& message,
     google::protobuf::io::CodedOutputStream output(rawOutput.get());
 
     // Write the size.
-    const int size = int(message.ByteSizeLong());
+    const size_t raw_size = message.ByteSizeLong();
+    if(raw_size > std::numeric_limits<int>::max()) {
+        std::cerr << __FILE__ << "(" << __LINE__ << "): Message size larger than max integer value" << std::endl;
+        return false;
+    }
+    const int size = static_cast<int>(raw_size);
     output.WriteVarint32(size);
 
     // cout << "Writing message of size: " << size << endl;

--- a/src/log/Log.cpp
+++ b/src/log/Log.cpp
@@ -309,7 +309,7 @@ bool Log::writeDelimitedTo(const google::protobuf::MessageLite& message,
     google::protobuf::io::CodedOutputStream output(rawOutput.get());
 
     // Write the size.
-    const int size = message.ByteSize();
+    const int size = int(message.ByteSizeLong());
     output.WriteVarint32(size);
 
     // cout << "Writing message of size: " << size << endl;

--- a/src/plugins/autonomy/ArduPilot/ArduPilot.cpp
+++ b/src/plugins/autonomy/ArduPilot/ArduPilot.cpp
@@ -47,7 +47,7 @@
 
 #include <GeographicLib/LocalCartesian.hpp>
 
-#include <boost/bind.hpp>
+#include <boost/bind/bind.hpp>
 #include <boost/asio/placeholders.hpp>
 #include <boost/asio/buffer.hpp>
 #include <boost/asio/basic_datagram_socket.hpp>


### PR DESCRIPTION
- Updated `boost/bind.hpp` to `boost/bind/bind.hpp`
- Switch to using protobuf's `ByteSizeLong()` instead of deprecated `ByteSize()`