### PR TITLE
Init's Recv Flags in ArduPilot Autonomy

### DIFF
--- a/src/plugins/autonomy/ArduPilot/ArduPilot.cpp
+++ b/src/plugins/autonomy/ArduPilot/ArduPilot.cpp
@@ -190,7 +190,7 @@ bool ArduPilot::step_autonomy(double t, double dt) {
         recv_io_service_.poll();
     } else {
         boost::system::error_code error;
-        ba::ip::udp::socket::message_flags flags;
+        ba::ip::udp::socket::message_flags flags = 0;
         std::size_t nbytes = recv_socket_->receive_from(
             ba::buffer(recv_buffer_), recv_remote_endpoint_,
             flags, error);


### PR DESCRIPTION
Initializes socket message flags for boost asio udp.