### PR TITLE
Minor fix to LibXML2Parser to persist Mission Overrides

### DIFF
--- a/include/scrimmage/parse/MissionParse.h
+++ b/include/scrimmage/parse/MissionParse.h
@@ -178,7 +178,10 @@ class MissionParse {
     bool read_file_content(const std::string &filename);
     std::string replace_overrides(std::string str);
 
-    template <class T>
+    template <class Parser>
+    bool parse_filecontents(Parser& doc);
+
+    template <class Parser>
     bool parse_mission();
 
     AttributeMap attributes_;

--- a/include/scrimmage/parse/XMLParser/LibXML2Parser.h
+++ b/include/scrimmage/parse/XMLParser/LibXML2Parser.h
@@ -120,6 +120,7 @@ class LibXML2ParserDocument : public XMLParserDocument<LibXML2ParserDocument> {
     bool parse_document(std::vector<char>& filecontent);
     LibXML2ParserNode find_first_node(const std::string& name) const;
     LibXML2ParserNode find_first_node() const;
+    const std::vector<char>& get_filecontents();
 
  protected:
     static constexpr int PARSING_OPTIONS = XML_PARSE_XINCLUDE | XML_PARSE_NOBLANKS;

--- a/src/parse/MissionParse.cpp
+++ b/src/parse/MissionParse.cpp
@@ -147,6 +147,37 @@ std::string MissionParse::replace_overrides(std::string str) {
 }
 
 template <class Parser>
+bool MissionParse::parse_filecontents(Parser& doc) {
+    doc.set_filename(mission_filename_);
+    // doc.parse requires a null terminated string that it can modify.
+    std::vector<char> mission_file_content_vec(mission_file_content_.size() + 1);
+    mission_file_content_vec.assign(mission_file_content_.begin(),
+                                    mission_file_content_.end());  // copy
+    mission_file_content_vec.push_back('\0');                      // shouldn't reallocate
+    return doc.parse(mission_file_content_vec);
+}
+
+template <>
+bool MissionParse::parse_filecontents<LibXML2Parser>(LibXML2Parser& doc) {
+    // LibXMLParser is used when other xml files are included via xinclude to create a composite 
+    // xml mission file. We need to parse this contents twice to ensure that proper override substitution
+    // occurs
+    doc.set_filename(mission_filename_);
+    std::vector<char> mission_file_content_vec(mission_file_content_.size());
+    mission_file_content_vec.assign(mission_file_content_.begin(),
+                                    mission_file_content_.end());  // copy
+    doc.parse(mission_file_content_vec); 
+    mission_file_content_vec = doc.get_filecontents();
+
+    mission_file_content_.assign(mission_file_content_vec.cbegin(), mission_file_content_vec.cend());
+    mission_file_content_ = replace_overrides(mission_file_content_);
+    mission_file_content_vec.assign(mission_file_content_.begin(),
+                                    mission_file_content_.end());
+    
+    return doc.parse(mission_file_content_vec);
+}
+
+template <class Parser>
 bool MissionParse::parse_mission() {
     // std::cout << "Parsing with " << typeid(Parser).name() << "\n";
     //  Parse the xml tree.
@@ -157,14 +188,15 @@ bool MissionParse::parse_mission() {
     auto parse_double = [&](std::string str) { return std::stod(replace_overrides(str)); };
 
     Parser doc;
-    doc.set_filename(mission_filename_);
-    // doc.parse requires a null terminated string that it can modify.
-    std::vector<char> mission_file_content_vec(mission_file_content_.size() + 1);
-    mission_file_content_vec.assign(mission_file_content_.begin(),
-                                    mission_file_content_.end());  // copy
-    mission_file_content_vec.push_back('\0');                      // shouldn't reallocate
-    doc.parse(mission_file_content_vec);
+    //doc.set_filename(mission_filename_);
+    //// doc.parse requires a null terminated string that it can modify.
+    //std::vector<char> mission_file_content_vec(mission_file_content_.size() + 1);
+    //mission_file_content_vec.assign(mission_file_content_.begin(),
+    //                                mission_file_content_.end());  // copy
+    //mission_file_content_vec.push_back('\0');                      // shouldn't reallocate
+    //doc.parse(mission_file_content_vec);
 
+    parse_filecontents(doc);
     auto runscript_node = doc.first_node("runscript");
     if (!runscript_node.is_valid()) {
         cout << "Missing runscript tag." << endl;

--- a/src/parse/XMLParser/LibXML2Parser.cpp
+++ b/src/parse/XMLParser/LibXML2Parser.cpp
@@ -184,7 +184,8 @@ bool LibXML2ParserDocument::parse_document(std::vector<char> &filecontent) {
   if(filecontent.back() == '\0') {
     filecontent.pop_back();
   }
-  doc_ = xmlReadMemory(filecontent.data(), filecontent.size(), filename_.c_str(), NULL, LibXML2ParserDocument::PARSING_OPTIONS);
+  filecontents_ = filecontent;
+  doc_ = xmlReadMemory(filecontents_.data(), filecontents_.size(), filename_.c_str(), NULL, LibXML2ParserDocument::PARSING_OPTIONS);
   if (doc_ != nullptr) {
     int ret = xmlXIncludeProcess(doc_);
     return ret == 0;
@@ -192,6 +193,24 @@ bool LibXML2ParserDocument::parse_document(std::vector<char> &filecontent) {
     return false;
   }
 }
+
+const std::vector<char>& LibXML2ParserDocument::get_filecontents() {
+    if (doc_ != nullptr) {
+        xmlChar* buffer;
+        int size;
+        xmlDocDumpMemoryEnc(doc_,
+                &buffer,
+                &size,
+                "UTF-8");
+
+        filecontents_.assign(&buffer[0], &buffer[size]);
+        xmlFree(buffer);
+    }
+    
+    return filecontents_;
+}
+
+
 
 LibXML2ParserNode LibXML2ParserDocument::find_first_node(const std::string &name) const {
   xmlNodePtr cur_node = nullptr;

--- a/src/parse/XMLParser/LibXML2Parser.cpp
+++ b/src/parse/XMLParser/LibXML2Parser.cpp
@@ -179,7 +179,12 @@ bool LibXML2ParserDocument::parse_document(const std::string &filename) {
 
 bool LibXML2ParserDocument::parse_document(std::vector<char> &filecontent) {
   LIBXML_TEST_VERSION;
-  doc_ = xmlReadFile(filename_.c_str(), NULL, LibXML2ParserDocument::PARSING_OPTIONS);
+  //doc_ = xmlReadFile(filename_.c_str(), NULL, LibXML2ParserDocument::PARSING_OPTIONS);
+  // Filecontents can not be null terminated
+  if(filecontent.back() == '\0') {
+    filecontent.pop_back();
+  }
+  doc_ = xmlReadMemory(filecontent.data(), filecontent.size(), filename_.c_str(), NULL, LibXML2ParserDocument::PARSING_OPTIONS);
   if (doc_ != nullptr) {
     int ret = xmlXIncludeProcess(doc_);
     return ret == 0;


### PR DESCRIPTION
LibXML2 parser was reading the original filecontents, not filecontents modified by the MissionParsers. This meant that any mission overrides used in files that also used xinclude were not persisted throughout the mission.