### PR TITLE
Updating documentation for <no_bin_logging> tag

### DIFF
--- a/docs/source/overview/xml-tags.rst
+++ b/docs/source/overview/xml-tags.rst
@@ -371,6 +371,9 @@ and match between the two paradigms for a single entity.
 
 - ``scale``: the initial scale of the vehicles in the gui (``default = 1.0``)
 
+- ``no_bin_logging``: Disables binary logging in Scrimmage. Signifigantly reduces the size of mission outputs, but 
+  will not have entity trajectories logged. (``default = false``) 
+
 Combining XML Files
 ===================
 


### PR DESCRIPTION
Adding <no_bin_logging> to documentation. No one knows that disabling bin logging (which creates massive log files) is already built into Scrimmage.