### PR TITLE
Finalize Simulation (addressing #506)

### DIFF
--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -658,7 +658,7 @@ bool SimControl::run_single_step(const int& loop_number) {
     run_send_contact_visuals(); // send updated visuals
 
     if (display_progress_) {
-        if (loop_number % 100 == 0) {
+        if (loop_number % 100 == 0 || t == tend_) {
             sc::display_progress((tend_ == 0) ? 1.0 : t / tend_);
         }
     }
@@ -1028,8 +1028,14 @@ bool SimControl::finalize() {
         }
     }
 
+    // Update final progress bar. Do this before accounting for last timestep to 
+    // have progress bar completed at 100%
+    sc::display_progress((tend_ == 0) ? 1.0 : t() / tend_);
+
     // account for last step
     set_time(t() - dt_);
+    
+
 
     // Save EntityPresentAtEnd messages
     for (EntityPtr &ent : ents_) {
@@ -1038,6 +1044,8 @@ bool SimControl::finalize() {
         pub_ent_pres_end_->publish(msg);
     }
 
+    run_networks();
+    run_metrics(); 
     run_logging();
 
     if (display_progress_) cout << endl;


### PR DESCRIPTION
SimControl publishes messages during the sim finalization step. These messages were not being received because the networks were not run after publishing these messages (This was brought up in issue #506). This PR addresses this, and updates the progress bar one more time during the finalization step.