### PR TITLE
run metrics and networks one final time

### DIFF
--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -1015,6 +1015,10 @@ bool SimControl::finalize() {
         }
     }
 
+    // Update final progress bar. Do this before accounting for last timestep to
+    // have progress bar completed at 100%
+    sc::display_progress((tend_ == 0) ? 1.0 : t() / tend_);
+
     // account for last step
     set_time(t() - dt_);
 
@@ -1025,6 +1029,8 @@ bool SimControl::finalize() {
         pub_ent_pres_end_->publish(msg);
     }
 
+    run_networks();
+    run_metrics();
     run_logging();
 
     if (display_progress_)


### PR DESCRIPTION
SimControl publishes messages during the sim finalization step. These messages were not being received because the networks were not run after publishing these messages (This was brought up in issue #506). This PR addresses this, and updates the progress bar one more time during the finalization step. Repurposed from waford's PR