### PR TITLE
change csv to deal in strings now and convert appended values into strings

### DIFF
--- a/include/scrimmage/common/CSV.h
+++ b/include/scrimmage/common/CSV.h
@@ -53,12 +53,10 @@ struct StringifyVisitor {
     bool double_is_scientific = true;
     int double_precision = 13;
 
-    std::string operator()(int value) const { return std::to_string(value); }
-    std::string operator()(unsigned int value) const { return std::to_string(value); }
-    std::string operator()(size_t value) const { return std::to_string(value); }
-    std::string operator()(long value) const { return std::to_string(value); }
+    std::string operator()(bool value) const { return value ? "true" : "false"; }
+    std::string operator()(uint64_t value) const { return std::to_string(value); }
+    std::string operator()(int64_t value) const { return std::to_string(value); }
     std::string operator()(const std::string& value) const { return value; }
-    std::string operator()(bool value) const { return value ? "True" : "False"; }
     std::string operator()(double value) const {
         // default precision values for double are not enough in many cases
         std::ostringstream conv;
@@ -79,8 +77,7 @@ namespace scrimmage {
 class CSV {
  public:
     typedef std::list<std::string> Headers;
-    typedef std::variant<bool, size_t, unsigned int, long, int, double, std::string>
-        PossibleVariantTypes;
+    typedef std::variant<bool, uint64_t, int64_t, std::string, double> PossibleVariantTypes;
     typedef std::list<std::pair<std::string, PossibleVariantTypes>> Pairs;
 
     ~CSV();

--- a/include/scrimmage/common/CSV.h
+++ b/include/scrimmage/common/CSV.h
@@ -34,18 +34,54 @@
 #define INCLUDE_SCRIMMAGE_COMMON_CSV_H_
 
 #include <fstream>
+#include <iomanip>
+#include <iostream>
 #include <list>
 #include <map>
 #include <memory>
+#include <sstream>
 #include <string>
 #include <utility>
+#include <variant>
+
+#include "scrimmage/parse/ParseUtils.h"
+
+namespace {
+struct StringifyVisitor {
+
+    bool double_is_fixed = true;
+    bool double_is_scientific = true;
+    int double_precision = 13;
+
+    std::string operator()(int value) const { return std::to_string(value); }
+    std::string operator()(unsigned int value) const { return std::to_string(value); }
+    std::string operator()(size_t value) const { return std::to_string(value); }
+    std::string operator()(long value) const { return std::to_string(value); }
+    std::string operator()(const std::string& value) const { return value; }
+    std::string operator()(bool value) const { return value ? "True" : "False"; }
+    std::string operator()(double value) const {
+        // default precision values for double are not enough in many cases
+        std::ostringstream conv;
+        if (double_is_fixed) {
+            conv << std::fixed;
+        }
+        if (double_is_scientific) {
+            conv << std::scientific;
+        }
+        conv << std::setprecision(double_precision) << value;
+        return conv.str();
+    }
+};
+}  // namespace
 
 namespace scrimmage {
 
 class CSV {
  public:
     typedef std::list<std::string> Headers;
-    typedef std::list<std::pair<std::string, double>> Pairs;
+    typedef std::variant<bool, size_t, unsigned int, long, int, double, std::string>
+        PossibleVariantTypes;
+    typedef std::list<std::pair<std::string, PossibleVariantTypes>> Pairs;
 
     ~CSV();
 
@@ -75,7 +111,11 @@ class CSV {
 
     size_t rows();
 
-    double at(int row, const std::string& header);
+    template <class T1>
+    T1 at(int row, const std::string& header) {
+        const int column = column_headers_.at(header);
+        return convert<T1>(table_.at(row).at(column));
+    }
 
     friend std::ostream& operator<<(std::ostream& os, const CSV& csv);
 
@@ -87,6 +127,8 @@ class CSV {
     void set_double_scientific(bool is_scientific) { double_is_scientific_ = is_scientific; }
 
  protected:
+    std::string get_csv_string(const PossibleVariantTypes& val) const;
+
     std::list<std::string> get_csv_line_elements(const std::string& str);
 
     void write_headers();
@@ -100,7 +142,7 @@ class CSV {
     // Key 1 : Row Index
     // Key 2 : Column Index
     // Value : Cell Value
-    std::map<int, std::map<int, double>> table_;
+    std::map<int, std::map<int, std::string>> table_;
     int next_row_ = 0;
 
     std::ofstream file_out_;
@@ -110,7 +152,6 @@ class CSV {
     int double_precision_ = 13;
     bool double_is_fixed_ = true;
     bool double_is_scientific_ = false;
-
     std::string headers_to_string() const;
     std::string rows_to_string() const;
     std::string row_to_string(const int& i) const;

--- a/src/common/CSV.cpp
+++ b/src/common/CSV.cpp
@@ -30,16 +30,12 @@
  *
  */
 
-#include <fstream>
-#include <iomanip>
-#include <iostream>
-#include <sstream>
+#include "scrimmage/common/CSV.h"
+
 #include <vector>
 
 #include <boost/algorithm/string.hpp>
 #include <boost/tokenizer.hpp>
-#include <scrimmage/parse/ParseUtils.h>
-#include "scrimmage/common/CSV.h"
 
 using std::cout;
 using std::endl;
@@ -73,14 +69,23 @@ void CSV::set_column_headers(const std::string& headers, bool write) {
     set_column_headers(headers_vec, write);
 }
 
+std::string CSV::get_csv_string(const PossibleVariantTypes& v) const {
+    return std::visit(
+        StringifyVisitor{
+            .double_is_fixed = double_is_fixed_,
+            .double_is_scientific = double_is_scientific_,
+            .double_precision = double_precision_},
+        v);
+}
+
 bool CSV::append(const Pairs& pairs, bool write, bool keep_in_memory) {
 
-    for (std::pair<std::string, double> pair : pairs) {
+    for (auto pair : pairs) {
         auto it = column_headers_.find(pair.first);
         if (it == column_headers_.end()) {
             cout << "Warning: column header doesn't exist: " << pair.first << endl;
         }
-        table_[next_row_][it->second] = pair.second;
+        table_[next_row_][it->second] = get_csv_string(pair.second);
     }
 
     if (write) {
@@ -163,22 +168,7 @@ std::string CSV::row_to_string(const int& row) const {
     std::vector<std::string> values(column_headers_.size(), no_value_str_);
     auto it_row = table_.find(row);
     for (auto& kv : it_row->second) {
-        if (static_cast<int64_t>(kv.second) == kv.second) {
-            values[kv.first] = std::to_string(static_cast<int64_t>(kv.second));
-        } else if (static_cast<double>(kv.second) == kv.second) {
-            // default precision values for double are not enough in many cases
-            std::ostringstream conv;
-            if (double_is_fixed_) {
-                conv << std::fixed;
-            }
-            if (double_is_scientific_) {
-                conv << std::scientific;
-            }
-            conv << std::setprecision(double_precision_) << kv.second;
-            values[kv.first] = conv.str();
-        } else {
-            values[kv.first] = std::to_string(kv.second);
-        }
+        values[kv.first] = kv.second;
     }
 
     // Append the rows to the resultant string
@@ -238,7 +228,7 @@ bool CSV::read_csv_from_string(const std::string& csv_str, const bool& contains_
             std::vector<std::string> tokens;
             boost::split(tokens, line, boost::is_any_of(","));
             for (unsigned int i = 0; i < tokens.size(); i++) {
-                table_[row_num][i] = std::stod(tokens[i]);
+                table_[row_num][i] = tokens[i];
             }
 
             // If this is the first line and the file doesn't contain a header,
@@ -282,11 +272,6 @@ void CSV::set_no_value_string(const std::string& str) {
 
 size_t CSV::rows() {
     return table_.size();
-}
-
-double CSV::at(int row, const std::string& header) {
-    const int column = column_headers_.at(header);
-    return table_.at(row).at(column);
 }
 
 std::list<std::string> CSV::get_csv_line_elements(const std::string& str) {

--- a/src/common/CSV.cpp
+++ b/src/common/CSV.cpp
@@ -80,7 +80,7 @@ std::string CSV::get_csv_string(const PossibleVariantTypes& v) const {
 
 bool CSV::append(const Pairs& pairs, bool write, bool keep_in_memory) {
 
-    for (auto pair : pairs) {
+    for (const auto& pair : pairs) {
         auto it = column_headers_.find(pair.first);
         if (it == column_headers_.end()) {
             cout << "Warning: column header doesn't exist: " << pair.first << endl;
@@ -161,27 +161,24 @@ std::string CSV::rows_to_string() const {
 }
 
 std::string CSV::row_to_string(const int& row) const {
-    std::string result = "";
+    std::ostringstream result;
 
-    // Initialize a vector with no value string. Iterate over
-    // column_headers, use column index to fill in column for values.
-    std::vector<std::string> values(column_headers_.size(), no_value_str_);
     auto it_row = table_.find(row);
-    for (auto& kv : it_row->second) {
-        values[kv.first] = kv.second;
+    if (it_row == table_.end()) {
+        return "";
     }
 
     // Append the rows to the resultant string
     unsigned int i = 0;
-    for (std::string str : values) {
-        result += str;
+    for (auto& kv : it_row->second) {
+        result << kv.second;
 
         if (i + 1 < values.size()) {
-            result += ",";
+            result << ",";
         }
         i++;
     }
-    return result;
+    return result.str();
 }
 
 bool CSV::to_csv(const std::string& filename) {


### PR DESCRIPTION
Right now, the CSV writer class can only handle writing doubles to the csv table object. These get converted into strings when writing to the actual CSV. To simplify things, the CSV writer should just maintain a map of strings, which allows us to write any data type we want to the CSV as long as we convert it to a string first. It introduces some extra pre-processing we have to do to recover data from a CSV, but I think the schema of `get<datatype>()` is already well established in scrimmage so its not a large burden. This also allows people the added control of determining how their data should be turned into a string instead of leaving it to the CSV writer to determine. I have left the scientific vs fixed schema in there but technically all that should be done before the CSV writer even sees the value. The Visitor stuff is a bit of a hacky way to leave some backward compatibility for the old Append method that only took a double.