### PR TITLE
docs: fix successful spelling in docs

### DIFF
--- a/docs/source/tutorials/create-project.rst
+++ b/docs/source/tutorials/create-project.rst
@@ -41,5 +41,5 @@ command will look like the following if it was successful: ::
   -- Generating done
   -- Build files have been written to: /path/to/scrimmage/my-scrimmage-plugins/build
 
-The ``make`` command should be succesful, but since we haven't created any
+The ``make`` command should be successful, but since we haven't created any
 plugins yet, nothing will be built.


### PR DESCRIPTION
Changes:
- `succesful` -> `successful` in `docs/source/tutorials/create-project.rst` (1 occurrence(s), preserving capitalization where applicable)

Verification:
- Applied an exact spelling-only replacement against the current upstream base branch.
- Checked the repository is not archived or a fork.
- Checked open PR titles and my open PRs before opening this PR.
