### PR TITLE
gRPC frontend enhancements

### DIFF
--- a/src/parse/MissionParse.cpp
+++ b/src/parse/MissionParse.cpp
@@ -951,6 +951,10 @@ bool MissionParse::parse_terrain() {
     utm_terrain_->set_enable_terrain(false);
     utm_terrain_->set_enable_extrusion(false);
 
+    utm_terrain_->set_latitude(latitude_origin());
+    utm_terrain_->set_longitude(longitude_origin());
+    utm_terrain_->set_altitude(altitude_origin());
+
     if (params_.count("terrain") > 0
         && find_terrain_files(params_["terrain"], terrain_parse, utm_terrain_)) {
         double x_easting;

--- a/src/parse/ParseUtils.cpp
+++ b/src/parse/ParseUtils.cpp
@@ -133,10 +133,14 @@ bool find_model_properties(
         if (fs::exists(model_file) && fs::is_regular_file(model_file)) {
             cv->set_model_file(model_file);
             mesh_found = true;
+        } else {
+            cv->set_model_file(cv_parse.params()["model"]);
         }
         if (fs::exists(texture_file) && fs::is_regular_file(texture_file)) {
             cv->set_texture_file(texture_file);
             texture_found = true;
+        } else {
+            cv->set_texture_file(cv_parse.params()["texture"]);
         }
     }
 

--- a/src/proto/scrimmage/proto/Visual.proto
+++ b/src/proto/scrimmage/proto/Visual.proto
@@ -28,6 +28,9 @@ message UTMTerrain {
         string extrusion_file = 18;
         string extrusion_property = 19;
         bool enable_extrusion = 20;
+        double latitude = 21;
+        double longitude = 22;
+        double altitude = 23;
 }
 
 message SimInfo {

--- a/src/simcontrol/SimControl.cpp
+++ b/src/simcontrol/SimControl.cpp
@@ -791,6 +791,30 @@ void SimControl::set_running_in_thread(bool running_in_thread) {
 }
 
 bool SimControl::start() {
+    if (mp_->params().count("stream_port") > 0 && mp_->params().count("stream_ip") > 0) {
+        if (mp_->network_gui()) {
+            outgoing_interface_->init_network(
+                Interface::client,
+                mp_->params()["stream_ip"],
+                std::stoi(mp_->params()["stream_port"]));
+
+            network_thread_ = std::thread(
+                &Interface::init_network,
+                &(*incoming_interface_),
+                Interface::server,
+                "localhost",
+                std::stoi(mp_->params()["stream_port"]) + 1);
+            network_thread_.detach();
+        } else {
+            outgoing_interface_->set_mode(Interface::shared);
+            incoming_interface_->set_mode(Interface::shared);
+        }
+
+    } else {
+        outgoing_interface_->set_mode(Interface::shared);
+        incoming_interface_->set_mode(Interface::shared);
+    }
+
     send_terrain();
 
     // Set the time parameters based on the mission file input
@@ -860,30 +884,6 @@ bool SimControl::start() {
 
     } else {
         end_conditions_.insert(EndConditionFlags::TIME);
-    }
-
-    if (mp_->params().count("stream_port") > 0 && mp_->params().count("stream_ip") > 0) {
-        if (mp_->network_gui()) {
-            outgoing_interface_->init_network(
-                Interface::client,
-                mp_->params()["stream_ip"],
-                std::stoi(mp_->params()["stream_port"]));
-
-            network_thread_ = std::thread(
-                &Interface::init_network,
-                &(*incoming_interface_),
-                Interface::server,
-                "localhost",
-                std::stoi(mp_->params()["stream_port"]) + 1);
-            network_thread_.detach();
-        } else {
-            outgoing_interface_->set_mode(Interface::shared);
-            incoming_interface_->set_mode(Interface::shared);
-        }
-
-    } else {
-        outgoing_interface_->set_mode(Interface::shared);
-        incoming_interface_->set_mode(Interface::shared);
     }
 
     // If the GlobalNetwork doesn't exist, add it.


### PR DESCRIPTION
While creating a gRPC frontend for scrimmage I realized the following changes might be useful:
1. Adding latitude, longitude, and altitude to the UTMTerrain protobuf makes it easier to load tiles and terrain for a given mission.
2. The model and texture files should be able to be local to the frontend and, if so, scrimmage shouldn't override the model and texture files for entities.
3. The gRPC network connection should be initialized before publishing information about the terrain so the frontend can receive the data.